### PR TITLE
Vectored IO and batching

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-all</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -69,72 +69,72 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-buffer</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-dns</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-haproxy</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http2</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-memcache</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-mqtt</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-redis</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-smtp</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-socks</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-stomp</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-xml</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-common</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
@@ -144,57 +144,57 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler-proxy</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-rxtx</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-sctp</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-udt</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-example</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
@@ -211,23 +211,23 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>4.1.13.5.dse</version>
+        <version>4.1.13.6.dse</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
     </dependencies>

--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-buffer</artifactId>

--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-codec-dns</artifactId>

--- a/codec-haproxy/pom.xml
+++ b/codec-haproxy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-codec-haproxy</artifactId>

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-codec-http</artifactId>

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-codec-http2</artifactId>

--- a/codec-memcache/pom.xml
+++ b/codec-memcache/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-codec-memcache</artifactId>

--- a/codec-mqtt/pom.xml
+++ b/codec-mqtt/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-codec-mqtt</artifactId>

--- a/codec-redis/pom.xml
+++ b/codec-redis/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-codec-redis</artifactId>

--- a/codec-smtp/pom.xml
+++ b/codec-smtp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-codec-smtp</artifactId>

--- a/codec-socks/pom.xml
+++ b/codec-socks/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-codec-socks</artifactId>

--- a/codec-stomp/pom.xml
+++ b/codec-stomp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-codec-stomp</artifactId>

--- a/codec-xml/pom.xml
+++ b/codec-xml/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-codec-xml</artifactId>

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-codec</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-common</artifactId>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-example</artifactId>

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-handler-proxy</artifactId>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-handler</artifactId>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-microbench</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <groupId>io.netty</groupId>
   <artifactId>netty-parent</artifactId>
   <packaging>pom</packaging>
-  <version>4.1.13.5.dse</version>
+  <version>4.1.13.6.dse</version>
 
   <name>Netty</name>
   <url>http://netty.io/</url>

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-resolver-dns</artifactId>

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-resolver</artifactId>

--- a/tarball/pom.xml
+++ b/tarball/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-tarball</artifactId>

--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-autobahn</artifactId>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-osgi</artifactId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-testsuite</artifactId>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
   <artifactId>netty-transport-native-epoll</artifactId>
 
@@ -345,7 +345,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.1.13.5.dse</version>
+      <version>4.1.13.6.dse</version>
     </dependency>
   </dependencies>
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AIOContext.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AIOContext.java
@@ -21,31 +21,30 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.CompletionHandler;
 import java.util.ArrayDeque;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 import io.netty.channel.ChannelException;
-import io.netty.util.collection.LongObjectHashMap;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 public class AIOContext {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(AIOContext.class);
 
+    static final int SECTOR_SIZE = 512;
+    static final int SECTOR_SIZE_MASK = SECTOR_SIZE - 1;
+
     private final long address;
-    private long nextId;
-    private final int maxOutstanding;
     private final int maxPending;
-    private final Map<Long, IORequest> outstandingRequests;
-    private final ArrayDeque<IORequest> pendingRequests;
+    private final Request[] outstandingRequests;
+    private final ArrayDeque<Batch> pendingBatches;
     private volatile boolean destroyed;
 
     AIOContext(long address, int maxOutstanding, int maxPending) {
         this.address = address;
-        this.maxOutstanding = maxOutstanding;
         this.maxPending = maxPending;
-        this.outstandingRequests = new LongObjectHashMap<IORequest>(maxOutstanding);
-        this.pendingRequests = new ArrayDeque<IORequest>(maxPending);
-        this.nextId = 0;
+        this.outstandingRequests = new Request[maxOutstanding];
+        this.pendingBatches = new ArrayDeque<Batch>(maxPending);
     }
 
     public void destroy() {
@@ -57,148 +56,366 @@ public class AIOContext {
         Native.destroyAIOContext(this);
     }
 
-    public long getNextId() {
-        return nextId++;
-    }
-
     public long getAddress() {
         return address;
     }
 
-    public <A> void read(final AIOEpollFileChannel file, final ByteBuffer dst, final long position, final A attachment,
-                         final CompletionHandler<Integer, ? super A> handler) {
+    public <A> void read(Batch<A> batch) {
         assert !destroyed;
-        assert file.epollEventLoop.aioContext == this;
+        assert batch.file.epollEventLoop.aioContext == this;
 
-        if (!file.verify(dst, position, attachment, handler)) {
-            return;
-        }
-
-        int length = (dst.limit() & AIOEpollFileChannel.SECTOR_SIZE_MASK) == 0 ? dst.limit() :
-                     ((dst.limit() + AIOEpollFileChannel.SECTOR_SIZE_MASK) & ~AIOEpollFileChannel.SECTOR_SIZE_MASK);
-        IORequest<A> request = new IORequest<A>(file, dst, position, length, handler, attachment);
-
-        try {
-            // Avoid sending overflowing the aio context queue (EAGAIN)
-            // instead buffer locally
-            if (outstandingRequests.size() < maxOutstanding) {
-                long id = Native.submitAIORead(this, file.getEventFd(), file.getFd(), position, length, dst);
-
-                IORequest r = outstandingRequests.putIfAbsent(id, request);
-                if (r != null) {
-                    handler.failed(new RuntimeException("ID already found: " + id), attachment);
-                }
-            } else {
-                addToPending(request, attachment, handler);
-            }
-        } catch (Throwable e) {
-            if (e instanceof ChannelException && e.getMessage().contains("Resource temporarily unavailable")) {
-                addToPending(request, attachment, handler);
-            } else {
-                logger.error("Error reading " + file.getFileObject().getAbsolutePath() + "@" + position, e);
-                handler.failed(e, attachment);
-            }
-        }
+        submitBatch(batch);
     }
 
-    private <A> void addToPending(final IORequest<A> request, final A attachment,
-                                     final CompletionHandler<Integer, ? super A> handler)
-    {
-        if (pendingRequests.size() >= maxPending) {
-            handler.failed(new RuntimeException("Too many pending requests"), attachment);
+    private int submitBatch(Batch<?> batch) {
+        if (logger.isTraceEnabled()) {
+            logger.trace("Received read batch {}", batch);
         }
-        boolean added = pendingRequests.offer(request);
-        assert added : "failed to add request";
+
+        if (!batch.file.isOpen()) {
+            batch.failed("File has been closed");
+            return 0;
+        }
+
+        int currentIndex = 0;
+        for (int i = 0; i < outstandingRequests.length; i++) {
+            if (outstandingRequests[i] != null) {
+                continue;
+            }
+
+            Request<?> current = batch.requests.get(currentIndex++);
+            outstandingRequests[i] = current;
+            current.slot = i;
+
+            if (currentIndex == batch.requests.size()) {
+                break;
+            }
+        }
+
+        if (currentIndex > 0) {
+            Batch<?> toSubmit = batch.split(0, currentIndex);
+            try {
+                Native.submitAIOReads(this, batch.file.getEventFd(), batch.file.getFd(), toSubmit.requests);
+            }  catch (Throwable e) {
+                if (e instanceof ChannelException && e.getMessage().contains("Resource temporarily unavailable")) {
+                    addToPending(toSubmit);
+                } else {
+                    logger.error("Error reading " + batch.file.getFileObject().getAbsolutePath()
+                            + "@" + batch.offset(), e);
+                    batch.failed(e);
+                }
+            }
+        }
+
+        if (currentIndex < batch.requests.size()) {
+            addToPending(batch.split(currentIndex, batch.requests.size()));
+        }
+
+        return currentIndex; // the number of requests submitted
     }
 
-    public void processReady(AIOEpollFileChannel file) {
-        assert !destroyed;
-        IORequest request = null;
-        long numReady;
+    private <A> void addToPending(final Batch<A> batch) {
+        if (pendingBatches.size() >= maxPending) {
+            batch.failed(new RuntimeException("Too many pending requests"));
+        }
+        boolean added = pendingBatches.offer(batch);
+        assert added : "failed to add request batch";
+    }
+
+    /**
+     * Process the read events for the given file.
+     */
+    void processReady(AIOEpollFileChannel file) {
+        assert !destroyed : "AIO context already destroyed";
         try {
-            numReady = Native.eventFdRead(file.getEventFd());
-
-            // Shouldn't happen
-            if (numReady == 0) {
-                return;
-            }
-
-            // Process the finished reads
-            long[] ids = Native.getAIOEvents(this, numReady);
-            assert ids.length == numReady * 2;
-            for (int i = 0; i < numReady; i++) {
-                long id = ids[i];
-                long lengthRead = ids[i + (int) numReady];
-                request = outstandingRequests.remove(id);
-                if (request == null) {
-                    throw new IllegalStateException("" + id + " missing");
-                }
-
-                // Finally complete the request
-                int len = (int) lengthRead;
-                assert len == lengthRead;
-                assert len >= 0 : len;
-                request.buffer.limit(len);
-                request.buffer.position(len);
-                request.handler.completed(len, request.attachment);
-            }
+            innerProcessReady(file);
         } catch (IOException e) {
             throw new IOError(e);
         } catch (Throwable t) {
-            long position = request == null ? -1 : request.position;
-            int length = request == null ? -1 : request.length;
-            logger.error("Error reading " + file.getFileObject().getAbsolutePath() + "@" + position + " - " +
-                         length, t);
+            logger.error("Error reading " + file.getFileObject().getAbsolutePath(), t);
             throw new RuntimeException(t);
         }
-
-        // We do this after processing the finished reads in case any outstanding reads
-        // share the same destination buffer
-        addPendingReads(numReady);
     }
 
-    public void addPendingReads(long numReady) {
-        for (int i = 0; i < numReady; i++) {
-            IORequest req = null;
-            try {
-                if (outstandingRequests.size() >= maxOutstanding || (req = pendingRequests.poll()) == null) {
-                    break; // too many outstanding requests or no more pending requests
-                }
-                long nextId = Native.submitAIORead(this, req.file.getEventFd(), req.file.getFd(),
-                        req.position, req.length, req.buffer);
-                IORequest r = outstandingRequests.putIfAbsent(nextId, req);
-                if (r != null) {
-                    req.handler.failed(new RuntimeException("ID already found: " + nextId), req.attachment);
-                }
+    private void innerProcessReady(AIOEpollFileChannel file) throws IOException {
+        long[] result = new long[outstandingRequests.length * 2];
+        int numReady = Native.getAIOEvents(this, result);
 
-            } catch (ChannelException e) {
-                if (req != null && e.getMessage().contains("Resource temporarily unavailable")) {
-                    pendingRequests.addFirst(req);
-                } else {
-                    throw e;
+        // this is fine, we read as many requests as available so it can happen that we race with
+        // an epoll event for the next request
+        if (numReady == 0) {
+            return;
+        }
+
+        List<Request> completedRequests = new ArrayList<Request>(numReady);
+        try {
+            for (int i = 0; i < numReady; i++) {
+                int slot = (int) result[i];
+                assert slot >= 0 && slot < outstandingRequests.length : "Invalid slot number: " + slot;
+                assert outstandingRequests[slot] != null : "Request at slot " + slot + " was null";
+
+                // nothing here should throw, completedRequests has already been pre-allocated
+                Request request = outstandingRequests[slot];
+                request.lengthRead = (int) result[i + numReady];
+                outstandingRequests[slot] = null;
+                completedRequests.add(request);
+            }
+
+            submitPendingReads(numReady);
+        } finally {
+            for (Request completedRequest : completedRequests) {
+                try {
+                    completedRequest.complete();
+                } catch (Throwable t) {
+                    logger.error("Error completing request {}", completedRequest, t);
                 }
-            } catch (IOException e) {
-                throw new IOError(e);
             }
         }
     }
 
-    class IORequest<A> {
-        public final AIOEpollFileChannel file;
-        public final ByteBuffer buffer;
-        public final CompletionHandler handler;
-        public final A attachment;
-        public final long position;
-        public final int length;
+    private void submitPendingReads(int numReady) {
+        int numSubmitted = 0;
+        while (numSubmitted < numReady) {
+            Batch batch = pendingBatches.poll();
+            if (batch == null) {
+                break;
+            }
 
-        IORequest(AIOEpollFileChannel file, ByteBuffer buffer, long position, int length, CompletionHandler handler,
-                  A attachment) {
+            numSubmitted += submitBatch(batch);
+        }
+    }
+
+    public static final class Batch<A> {
+        private final AIOEpollFileChannel file;
+        private final boolean vectored;
+        private final List<Request<A>> requests;
+
+        Batch(AIOEpollFileChannel file, boolean vectored) {
+            this(file, vectored, new ArrayList<Request<A>>());
+        }
+
+        Batch(AIOEpollFileChannel file, boolean vectored, List<Request<A>> requests) {
             this.file = file;
+            this.vectored = vectored;
+            this.requests = requests;
+        }
+
+        public Batch<A> add(final long offset, final ByteBuffer buffer,
+                            final A attachment, final CompletionHandler<Integer, ? super A> handler) {
+
+            if (vectored) {
+                for (Request<A> request : requests) {
+                    if (request.maybeAdd(offset, buffer, handler, attachment)) {
+                        return this;
+                    }
+                }
+            }
+
+            this.requests.add(new Request<A>(-1, offset, buffer, handler, attachment));
+            return this;
+        }
+
+        public long offset() {
+            return requests.get(0).offset;
+        }
+
+        boolean verify() {
+            boolean ret = true;
+            for (Request<A> request : requests) {
+                ret &= request.verify(file);
+            }
+            return ret;
+        }
+
+        void failed(String error) {
+            for (Request<A> request : requests) {
+                request.failed(error);
+            }
+        }
+
+        void failed(Throwable t) {
+            for (Request<A> request : requests) {
+                request.failed(t);
+            }
+        }
+
+        Batch<A> split(int fromIndex, int toIndex) {
+            return fromIndex == 0 && toIndex == requests.size()
+                    ? this
+                    : new Batch<A>(file, vectored, requests.subList(fromIndex, toIndex));
+        }
+
+        public int numRequests() {
+            return requests.size();
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder str = new StringBuilder();
+            str.append("Batch:\n");
+            for (Request<A> req: requests) {
+                str.append(req.toString()).append("\n");
+            }
+            return str.toString();
+        }
+    }
+
+    static final class BufferHolder<A> {
+        final ByteBuffer buffer;
+        final A attachment;
+        final CompletionHandler<Integer, ? super A> handler;
+
+        BufferHolder(ByteBuffer buffer, A attachment, CompletionHandler<Integer, ? super A> handler) {
             this.buffer = buffer;
-            this.position = position;
-            this.length = length;
-            this.handler = handler;
             this.attachment = attachment;
+            this.handler = handler;
+        }
+
+        Throwable verify() {
+            if (!buffer.isDirect()) {
+                return new IllegalArgumentException("ByteBuffer is not direct");
+            }
+
+            if (buffer.position() != 0) {
+                return new IllegalArgumentException("ByteBuffer position must be 0");
+            }
+
+            if ((buffer.limit() & SECTOR_SIZE_MASK) != 0) {
+                return new IllegalArgumentException(String.format("ByteBuffer limit must be aligned to %d",
+                        SECTOR_SIZE));
+            }
+
+            return null;
+        }
+
+        void failed(Throwable t) {
+            handler.failed(t, attachment);
+        }
+
+        void completed(int pos) {
+            buffer.position(pos).limit(pos); // shrink limit to position to indicate buffer is fully filled
+            handler.completed(buffer.limit(), attachment);
+        }
+
+        int limit() {
+            return buffer.limit();
+        }
+    }
+
+    public static final class Request<A> {
+        int slot;
+        final long offset;
+        final List<BufferHolder<A>> buffers;
+        int lengthRead;
+        boolean completed;
+        Throwable error;
+
+        Request(int slot, long offset, ByteBuffer buffer) {
+            this(slot, offset, buffer, null, null);
+        }
+
+        Request(int slot, long offset, ByteBuffer buffer,
+                CompletionHandler<Integer, ? super A> handler, A attachment) {
+            this(slot, offset);
+            this.buffers.add(new BufferHolder<A>(buffer, attachment, handler));
+        }
+
+        Request(int slot, long offset) {
+            this.slot = slot;
+            this.offset = offset;
+            this.buffers = new ArrayList<BufferHolder<A>>(1);
+            this.lengthRead = -1;
+        }
+
+        boolean maybeAdd(long offset, ByteBuffer buffer, CompletionHandler<Integer, ? super A> handler, A attachment) {
+            // for now there is a limitation native side of max 8 buffers per request, perhaps we need to remove this
+            if (this.buffers.size() < 8 && offset == this.offset + totLength()) {
+                this.buffers.add(new BufferHolder<A>(buffer, attachment, handler));
+                return true;
+            }
+
+            return false;
+        }
+
+        boolean verify(AIOEpollFileChannel file) {
+            if (!file.isOpen()) {
+                failed(new IOException("File has been closed"));
+                return false;
+            }
+
+            if (offset < 0) {
+                failed(new IllegalArgumentException("Position must be >= 0"));
+                return false;
+            }
+
+            if ((offset & SECTOR_SIZE_MASK) != 0) {
+                failed(new IOException(String.format(
+                        "Read position must be aligned to sector size (usually %d)", SECTOR_SIZE)));
+                return false;
+            }
+
+            for (BufferHolder<A> buffer : buffers) {
+                Throwable err = buffer.verify();
+                if (err != null) {
+                    failed(err);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        void failed(String error) {
+            failed(new IOException(error));
+        }
+
+        void failed(Throwable t) {
+            for (BufferHolder<A> buffer : buffers) {
+                buffer.failed(t);
+            }
+        }
+
+        int totLength() {
+            int ret = 0;
+            for (BufferHolder<A> buffer : buffers) {
+                ret += buffer.limit();
+            }
+
+            return ret;
+        }
+
+        void complete() {
+            assert !completed : "Request already completed";
+            completed = true;
+
+            if (error != null) {
+                failed(error);
+                return;
+            }
+
+            assert lengthRead >= 0 : String.format("Read negative length: %d", lengthRead);
+            assert lengthRead <= totLength() : String.format("Read more than requested: %d > %d",
+                    lengthRead, totLength());
+
+            int remaining = lengthRead;
+            for (BufferHolder<A> buffer : buffers) {
+                int pos = remaining > 0 ? Math.min(buffer.limit(), remaining) : 0;
+                buffer.completed(pos);
+                remaining -= pos;
+            }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder str = new StringBuilder();
+            str.append("Slot: ").append(slot).append(", ");
+            str.append("Offset: ").append(offset).append(", ");
+            str.append("Num buffers: ").append(buffers.size()).append(" [");
+            for (BufferHolder<A> buffer : buffers) {
+                str.append(buffer.buffer.limit()).append(", ");
+            }
+            str.append("]");
+            return str.toString();
         }
     }
 }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/LibAIOTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/LibAIOTest.java
@@ -17,26 +17,30 @@ package io.netty.channel.epoll;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.CompletionHandler;
+import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-
 import io.netty.util.SuppressForbidden;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -45,13 +49,17 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.util.internal.PlatformDependent;
 import sun.misc.SharedSecrets;
+import sun.nio.ch.DirectBuffer;
 
 
 public class LibAIOTest {
 
+    private static Random random = new Random();
+
     @BeforeClass
     public static void setup() {
         System.setProperty("netty.aio.maxConcurrency", "1");
+        random.setSeed(15414594750175L);
     }
 
     @Test
@@ -61,47 +69,163 @@ public class LibAIOTest {
     }
 
     @Test
-    @SuppressForbidden(reason = "to test native aio reads")
-    public void nativeReadTest() throws IOException, InterruptedException {
+    @SuppressForbidden(reason = "to test a simple native aio read")
+    public void nativeReadTestSingleRequest() throws IOException, InterruptedException {
         EventLoopGroup group = new EpollEventLoopGroup(1);
-        File file = File.createTempFile("netty-aio", null);
-        file.deleteOnExit();
-
-        String value = "AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKKKLLLLMMMMNNNNOOOOPPPPQQQQRRRR" +
-                       "SSSSTTTUUUUVVVVWWWWXXXXYYYYZZZZ";
-
-        int len = 0;
-        FileWriter write = new FileWriter(file);
-        for (int i = 0; i < 1024; i++) {
-            write.append(value);
-            len += value.length();
-        }
-
-        write.flush();
-        write.close();
-        FileInputStream fileReader = new FileInputStream(file);
-
         EpollEventLoop loop = (EpollEventLoop) group.next();
 
-            AIOContext aio = Native.createAIOContext(1, 1);
+        FileInputStream fileReader = new FileInputStream(createFile("netty-aio-single", 65536));
 
-            try {
-            ByteBuffer buf = allocateAlignedByteBuffer(65536, 512);
+        final int maxConcurrency = 8;
+        AIOContext aio = Native.createAIOContext(maxConcurrency, 1);
 
-            long id = Native.submitAIORead(aio, loop.eventFd.intValue(),
-                                           SharedSecrets.getJavaIOFileDescriptorAccess().get(fileReader.getFD()),
-                                           0, 65536, buf);
+        try {
+            for (int slot = 0; slot < maxConcurrency; slot++) {
 
-            long[] ids = Native.getAIOEvents(aio, 1);
+                ByteBuffer buf = allocateAlignedByteBuffer(65536, 512);
 
-            Assert.assertEquals(id, ids[0]);
-            byte[] output = new byte[value.length()];
-            buf.get(output);
-            Assert.assertEquals(value, new String(output));
+                Native.submitAIORead(aio, loop.eventFd.intValue(),
+                        SharedSecrets.getJavaIOFileDescriptorAccess().get(fileReader.getFD()),
+                        new AIOContext.Request(slot, 0, buf));
+
+                long[] result = new long[2];
+                int numEvents = Native.getAIOEvents(aio, result);
+
+                Assert.assertEquals(1, numEvents);
+                Assert.assertEquals(slot, result[0]);
+
+                checkContent(fileReader, buf, 0, 65536);
+
+                freeAlignedByteBuffer(buf);
+            }
 
             group.shutdownGracefully();
         } finally {
             aio.destroy();
+            fileReader.close();
+        }
+    }
+
+    @Test
+    @SuppressForbidden(reason = "to test multiple native aio reads")
+    public void nativeReadTestMultipleRequests() throws IOException, InterruptedException {
+        EventLoopGroup group = new EpollEventLoopGroup(1);
+        EpollEventLoop loop = (EpollEventLoop) group.next();
+
+        final int maxConcurrency = 8;
+        final int fileSize = 524288;
+
+        FileInputStream fileReader = new FileInputStream(createFile("netty-aio-multiple", fileSize));
+        AIOContext aio = Native.createAIOContext(maxConcurrency, 1);
+
+        final int numTrials = 5000;
+        final int eventFd = loop.eventFd.intValue();
+        final int fileFd = SharedSecrets.getJavaIOFileDescriptorAccess().get(fileReader.getFD());
+
+        try {
+            for (int t = 0; t < numTrials; t++) {
+                int numRequests = 1 + random.nextInt(maxConcurrency - 1);
+
+                Map<Integer, AIOContext.Request<Void>> requests = new HashMap<Integer, AIOContext.Request<Void>>();
+                for (int r = 0; r < numRequests; r++) {
+                    int numBuffers = 1 + random.nextInt(8);
+                    int bufferSize = (int) Math.max(AIOContext.SECTOR_SIZE,
+                            roundDownToBlockSize(random.nextInt(fileSize / numBuffers)));
+                    Assert.assertTrue(String.format("File size %d exceeded: %d buffers of size %d",
+                            fileSize, numBuffers, bufferSize),
+                            (numBuffers * bufferSize) <= fileSize);
+                    long offset = roundDownToBlockSize(random.nextInt(fileSize - (numBuffers * bufferSize)));
+
+                    List<ByteBuffer> buffers = new ArrayList<ByteBuffer>(numBuffers);
+                    for (int i = 0; i < numBuffers; i++) {
+                        buffers.add(allocateAlignedByteBuffer(bufferSize, AIOContext.SECTOR_SIZE));
+                    }
+
+                    AIOContext.Request<Void> request = new AIOContext.Request<Void>(r, offset);
+                    for (int i = 0; i < buffers.size(); i++) {
+                        Assert.assertTrue(request.maybeAdd(offset + i * bufferSize, buffers.get(i), null, null));
+                    }
+
+                    requests.put(r, request);
+                }
+
+                //System.out.println("Submitting requests: " + requests.values());
+                Native.submitAIOReads(aio, eventFd, fileFd, requests.values());
+
+                long[] result = new long[numRequests * 2];
+                int numEvents = Native.getAIOEvents(aio, result);
+                Assert.assertEquals(numRequests, numEvents);
+
+                for (int i = 0; i < numRequests; i++) {
+                    int slot = (int) result[i];
+                    int totRead = (int) result[numRequests + i];
+
+                    AIOContext.Request<?> request = requests.get(slot);
+                    Assert.assertNotNull(request);
+
+                    Assert.assertEquals(request.totLength(), totRead);
+
+                    long offset = request.offset;
+                    for (AIOContext.BufferHolder<?> buffer : request.buffers) {
+                        checkContent(fileReader, buffer.buffer, offset, buffer.limit());
+                        offset += buffer.limit();
+
+                        freeAlignedByteBuffer(buffer.buffer);
+                    }
+                }
+            }
+
+            group.shutdownGracefully();
+        } finally {
+            aio.destroy();
+            fileReader.close();
+        }
+    }
+
+//    private static int roundUpToBlockSize(int size) {
+//        return (size + AIOContext.SECTOR_SIZE - 1) & -AIOContext.SECTOR_SIZE;
+//    }
+
+    private static long roundDownToBlockSize(long size) {
+        return size & -AIOContext.SECTOR_SIZE;
+    }
+
+    private File createFile(String fileName, int size) throws IOException {
+        File file = File.createTempFile(fileName, null);
+        file.deleteOnExit();
+
+        ByteBuffer data = ByteBuffer.allocate(size);
+        random.nextBytes(data.array());
+
+        FileChannel channel = new FileOutputStream(file, true).getChannel();
+        channel.write(data);
+        channel.force(false);
+        channel.close();
+
+        return file;
+    }
+
+    private void checkContent(FileInputStream fileReader, ByteBuffer buffer, long offset, int length)
+            throws IOException {
+        FileChannel channel = fileReader.getChannel();
+        ByteBuffer expected = ByteBuffer.allocate(length);
+        channel.read(expected, offset);
+
+        byte[] output = new byte[length];
+        buffer.get(output);
+
+        Assert.assertArrayEquals(expected.array(), output);
+    }
+
+    @Test
+    public void epollTriggeredSingleThreadReadTest() throws IOException, InterruptedException, ExecutionException {
+        int old = EpollEventLoop.aioPerLoopMaxConcurrency;
+        try {
+            EpollEventLoop.aioPerLoopMaxConcurrency = 8;
+            Collection<Exception> errors = epollTriggeredReadTest(1024, 1, 1);
+            Assert.assertTrue(errors.isEmpty());
+        } finally {
+            EpollEventLoop.aioPerLoopMaxConcurrency = old;
         }
     }
 
@@ -113,23 +237,23 @@ public class LibAIOTest {
 
     @Test
     public void epollTriggeredReadTestHigherConcurrency() throws IOException, InterruptedException, ExecutionException {
-        int old = EpollEventLoop.aioMaxConcurrency;
+        int old = EpollEventLoop.aioPerLoopMaxConcurrency;
         try {
-            EpollEventLoop.aioMaxConcurrency = 128;
+            EpollEventLoop.aioPerLoopMaxConcurrency = 16;
             Collection<Exception> errors = epollTriggeredReadTest(1024, 16, 8);
             Assert.assertTrue(errors.isEmpty());
         } finally {
-            EpollEventLoop.aioMaxConcurrency = old;
+            EpollEventLoop.aioPerLoopMaxConcurrency = old;
         }
     }
 
     @Test
     public void epollTriggeredReadTestLowMaxPending() throws IOException, InterruptedException, ExecutionException {
-        int oldConcurrency = EpollEventLoop.aioMaxConcurrency;
+        int oldConcurrency = EpollEventLoop.aioPerLoopMaxConcurrency;
         int oldPedning = EpollEventLoop.aioPerLoopMaxPending;
 
         try {
-            EpollEventLoop.aioMaxConcurrency = 128;
+            EpollEventLoop.aioPerLoopMaxConcurrency = 16;
             EpollEventLoop.aioPerLoopMaxPending = 32;
             Collection<Exception> errors = epollTriggeredReadTest(1024, 8, 4);
             Assert.assertFalse(errors.isEmpty()); // some requests should have failed with "Too many pending requests"
@@ -138,39 +262,22 @@ public class LibAIOTest {
                 Assert.assertTrue(error.getMessage().contains("Too many pending requests"));
             }
         } finally {
-            EpollEventLoop.aioMaxConcurrency = oldConcurrency;
+            EpollEventLoop.aioPerLoopMaxConcurrency = oldConcurrency;
             EpollEventLoop.aioPerLoopMaxPending = oldPedning;
         }
     }
 
-    private Collection<Exception> epollTriggeredReadTest(final int requests, final int numThreads, final int numLoops)
+    private Collection<Exception> epollTriggeredReadTest(final int trials, final int numThreads, final int numLoops)
             throws IOException, InterruptedException {
-        final int LEN = 65536;
+        final int fileSize = 65536;
         final EventLoopGroup group = new EpollEventLoopGroup(numLoops, true);
         final EpollEventLoop[] loops = new EpollEventLoop[numLoops];
         for (int i = 0; i < numLoops; i++) {
             loops[i] = (EpollEventLoop) group.next();
         }
 
-        final File file = File.createTempFile("netty-aio", null);
-        file.deleteOnExit();
-
-        //Make value 1 page
-        String tmp = "AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKKKLLLLMMMMNNNNOOOOPPPPQQQQRRRR" +
-                       "SSSSTTTUUUUVVVVWWWWXXXXYYYYZZZZ";
-
-        while (tmp.length() < LEN) {
-            tmp += tmp;
-        }
-
-        final String value = tmp.substring(0, LEN);
-        FileWriter write = new FileWriter(file);
-        for (int i = 0; i < requests; i++) {
-            write.append(value);
-        }
-
-        write.flush();
-        write.close();
+        final File file = createFile("netty-aio-epoll", fileSize);
+        final FileInputStream fileReader = new FileInputStream(file);
 
         final AtomicReference<Throwable> err = new AtomicReference<Throwable>();
         ExecutorService es = Executors.newFixedThreadPool(numThreads);
@@ -185,37 +292,76 @@ public class LibAIOTest {
                     try {
                         final EpollEventLoop loop = loops[tid % numLoops];
 
-                        AsynchronousFileChannel fc = new AIOEpollFileChannel(file, loop, FileDescriptor.O_RDONLY |
-                                                                             FileDescriptor.O_DIRECT);
-                        List<ImmutablePair<ByteBuffer, Future<Integer>>> futures =
-                            new ArrayList<ImmutablePair<ByteBuffer, Future<Integer>>>();
+                        AIOEpollFileChannel fc = new AIOEpollFileChannel(file, loop,
+                                FileDescriptor.O_RDONLY | FileDescriptor.O_DIRECT);
+                        List<CompletableFuture> futures = new ArrayList<CompletableFuture>();
+                        final AtomicInteger totRead = new AtomicInteger(0);
+                        int totExpected = 0;
 
-                        for (int i = 0; i < requests; i++) {
-                            //System.err.println(loop.threadProperties().name());
-                            ByteBuffer buf = allocateAlignedByteBuffer(LEN, 512);
+                        for (int i = 0; i < trials; i++) {
+                            final boolean vectored = random.nextBoolean();
+                            final AIOContext.Batch<Pair<Long, ByteBuffer>> batch = new AIOContext.Batch(fc, vectored);
+                            final int numBuffers = 1 + random.nextInt(8);
+                            final int bufferSize = (int) Math.max(AIOContext.SECTOR_SIZE,
+                                    roundDownToBlockSize(random.nextInt(fileSize / numBuffers)));
+                            Assert.assertTrue(String.format("File size %d exceeded: %d buffers of size %d",
+                                    fileSize, numBuffers, bufferSize),
+                                    (numBuffers * bufferSize) <= fileSize);
+                            long offset = roundDownToBlockSize(random.nextInt(fileSize -
+                                                                                 (numBuffers * bufferSize)));
 
-                            buf.clear();
-                            futures.add(new ImmutablePair<ByteBuffer,
-                                                         Future<Integer>>(buf, fc.read(buf,
-                                                                                       value.length() *
-                                                                                       (i % requests))));
-                        }
-
-                        for (int i = 0; i < requests; i++) {
-                            try {
-                                int len = futures.get(i).getRight().get();
-                                ByteBuffer buf = futures.get(i).getLeft();
-                                buf.flip();
-                                Assert.assertEquals(buf.position(), 0);
-                                Assert.assertEquals(buf.limit(), len);
-
-                                byte[] output = new byte[value.length()];
-                                buf.get(output);
-                                Assert.assertEquals(value, new String(output));
-                            } catch (Exception ex) {
-                                errors.add(ex); // exceptions when completing the future are handled by the callers
+                            totExpected += numBuffers * bufferSize;
+                            final List<ByteBuffer> buffers = new ArrayList<ByteBuffer>(numBuffers);
+                            for (int b = 0; b < numBuffers; b++) {
+                                buffers.add(allocateAlignedByteBuffer(bufferSize, AIOContext.SECTOR_SIZE));
                             }
+
+                            for (ByteBuffer buffer : buffers) {
+                                final CompletableFuture fut = new CompletableFuture();
+                                futures.add(fut);
+                                batch.add(offset, buffer, Pair.of(offset, buffer),
+                                        new CompletionHandler<Integer, Pair<Long, ByteBuffer>>() {
+
+                                    @Override
+                                    public void completed(Integer read, Pair<Long, ByteBuffer> attachment) {
+
+                                        try {
+                                            long pos = attachment.getLeft();
+                                            ByteBuffer buffer = attachment.getRight();
+                                            buffer.flip();
+                                            checkContent(fileReader, buffer, pos, buffer.limit());
+                                            freeAlignedByteBuffer(buffer);
+                                            totRead.addAndGet(read);
+                                            fut.complete(null);
+
+                                        } catch (Throwable t) {
+                                            fut.completeExceptionally(t);
+                                        }
+                                    }
+
+                                    @Override
+                                    public void failed(Throwable exc, Pair<Long, ByteBuffer> attachment) {
+                                        fut.completeExceptionally(exc);
+                                    }
+                                });
+
+                                offset += bufferSize;
+                            }
+
+                            if (!vectored) {
+                                Assert.assertEquals(numBuffers, batch.numRequests());
+                            }
+
+                            fc.read(batch);
                         }
+
+                        try {
+                            CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).join();
+                            Assert.assertEquals(totExpected, totRead.get());
+                        } catch (Exception ex) {
+                            errors.add(ex); // exceptions when completing the future are handled by the callers
+                        }
+
                     } catch (Throwable t) {
                         System.err.println("Thread: " + tid + ", Index: " + idx);
                         t.printStackTrace();
@@ -234,7 +380,86 @@ public class LibAIOTest {
         return errors;
     }
 
-    public static ByteBuffer allocateAlignedByteBuffer(int capacity, long align) {
+    @Test
+    public void epollTriggeredSingleReadTest() throws Exception {
+        final int fileSize = 65536;
+        final int numTrials = 1024;
+        EventLoopGroup group = new EpollEventLoopGroup(1, true);
+        EpollEventLoop loop = (EpollEventLoop) group.next();
+
+        final File file = createFile("netty-aio-epoll-single", fileSize);
+        final FileInputStream fileReader = new FileInputStream(file);
+
+        final AIOEpollFileChannel fc = new AIOEpollFileChannel(file, loop,
+                FileDescriptor.O_RDONLY | FileDescriptor.O_DIRECT);
+
+        for (int i = 0; i < numTrials; i++) {
+            final int bufferSize = (int) Math.max(AIOContext.SECTOR_SIZE,
+                    roundDownToBlockSize(random.nextInt(fileSize)));
+            final long offset = roundDownToBlockSize(random.nextInt(fileSize - bufferSize));
+            final ByteBuffer buffer = allocateAlignedByteBuffer(bufferSize, AIOContext.SECTOR_SIZE);
+
+            fc.read(buffer, offset).get();
+            buffer.flip();
+            checkContent(fileReader, buffer, offset, bufferSize);
+        }
+    }
+
+    @Test
+    public void epollTriggeredReadLargerThanFileTest() throws Exception {
+        final int fileSize = 10000;
+        EventLoopGroup group = new EpollEventLoopGroup(1, true);
+        EpollEventLoop loop = (EpollEventLoop) group.next();
+
+        final File file = createFile("netty-aio-epoll-single", fileSize);
+        final FileInputStream fileReader = new FileInputStream(file);
+
+        final AIOEpollFileChannel fc = new AIOEpollFileChannel(file, loop,
+                FileDescriptor.O_RDONLY | FileDescriptor.O_DIRECT);
+
+        final int bufferSize = 4096;
+        long offset = 0;
+        final int numBuffers = 4; // 2 full buffers, 1 partially filled, 1 empty
+        final List<ByteBuffer> buffers = new ArrayList<ByteBuffer>(numBuffers);
+        for (int i = 0; i < numBuffers; i++) {
+            buffers.add(allocateAlignedByteBuffer(bufferSize, AIOContext.SECTOR_SIZE));
+        }
+
+        final CountDownLatch latch = new CountDownLatch(buffers.size());
+        final AtomicReference<Throwable> err = new AtomicReference<Throwable>(null);
+
+        AIOContext.Batch<Pair<Long, ByteBuffer>> batch = fc.newBatch();
+        for (ByteBuffer buffer : buffers) {
+            batch.add(offset, buffer, Pair.of(offset, buffer),
+                    new CompletionHandler<Integer, Pair<Long, ByteBuffer>>() {
+                @Override
+                public void completed(Integer read, Pair<Long, ByteBuffer> attachment) {
+                    try {
+                        long pos = attachment.getLeft();
+                        ByteBuffer buff = attachment.getRight();
+                        buff.flip();
+                        checkContent(fileReader, buff, pos, buff.limit());
+                        latch.countDown();
+                    } catch (Throwable t) {
+                        failed(t, attachment);
+                    }
+                }
+
+                @Override
+                public void failed(Throwable exc, Pair<Long, ByteBuffer> attachment) {
+                    err.set(exc);
+                    latch.countDown();
+                }
+            });
+            offset += bufferSize;
+        }
+
+        fc.read(batch);
+        latch.await();
+        Assert.assertNull(err.get());
+    }
+
+    static ByteBuffer allocateAlignedByteBuffer(int capacity, long align) {
         // Power of 2 --> single bit, none power of 2 alignments are not allowed.
         if (Long.bitCount(align) != 1) {
             throw new IllegalArgumentException("Alignment must be a power of 2");
@@ -261,5 +486,9 @@ public class LibAIOTest {
             // the slice is now an aligned buffer of the required capacity
             return buffy.slice().order(ByteOrder.nativeOrder());
         }
+    }
+
+    static void freeAlignedByteBuffer(ByteBuffer buffer) {
+        PlatformDependent.freeDirectNoCleaner((ByteBuffer) ((DirectBuffer) buffer).attachment());
     }
 }

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
   <artifactId>netty-transport-native-kqueue</artifactId>
 

--- a/transport-native-unix-common-tests/pom.xml
+++ b/transport-native-unix-common-tests/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
   <artifactId>netty-transport-native-unix-common-tests</artifactId>
 

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
   <artifactId>netty-transport-native-unix-common</artifactId>
 

--- a/transport-rxtx/pom.xml
+++ b/transport-rxtx/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-transport-rxtx</artifactId>

--- a/transport-sctp/pom.xml
+++ b/transport-sctp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-transport-sctp</artifactId>

--- a/transport-udt/pom.xml
+++ b/transport-udt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-transport-udt</artifactId>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.5.dse</version>
+    <version>4.1.13.6.dse</version>
   </parent>
 
   <artifactId>netty-transport</artifactId>


### PR DESCRIPTION
This is the Netty pull request for [DB-1349](https://datastax.jira.com/browse/DB-1349).

It supports batching, which consists of submitting multiple independent requests via a single `io_submit` call, and vectored IO, which consists of reading multiple sequential buffers in a single request.

@tjake, without urgency, would you mind reviewing this? 

