### PR TITLE
DB-1463 -  bind event fd to the AIO context and add config

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-all</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -69,72 +69,72 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-buffer</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-dns</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-haproxy</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http2</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-memcache</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-mqtt</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-redis</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-smtp</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-socks</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-stomp</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-xml</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-common</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
@@ -144,57 +144,57 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler-proxy</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-rxtx</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-sctp</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-udt</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-example</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
@@ -211,23 +211,23 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>4.1.13.6.dse</version>
+        <version>4.1.13.7.dse</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
     </dependencies>

--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-buffer</artifactId>

--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-dns</artifactId>

--- a/codec-haproxy/pom.xml
+++ b/codec-haproxy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-haproxy</artifactId>

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-http</artifactId>

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-http2</artifactId>

--- a/codec-memcache/pom.xml
+++ b/codec-memcache/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-memcache</artifactId>

--- a/codec-mqtt/pom.xml
+++ b/codec-mqtt/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-mqtt</artifactId>

--- a/codec-redis/pom.xml
+++ b/codec-redis/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-redis</artifactId>

--- a/codec-smtp/pom.xml
+++ b/codec-smtp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-smtp</artifactId>

--- a/codec-socks/pom.xml
+++ b/codec-socks/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-socks</artifactId>

--- a/codec-stomp/pom.xml
+++ b/codec-stomp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-stomp</artifactId>

--- a/codec-xml/pom.xml
+++ b/codec-xml/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-xml</artifactId>

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-codec</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-common</artifactId>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-example</artifactId>

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-handler-proxy</artifactId>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-handler</artifactId>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-microbench</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <groupId>io.netty</groupId>
   <artifactId>netty-parent</artifactId>
   <packaging>pom</packaging>
-  <version>4.1.13.6.dse</version>
+  <version>4.1.13.7.dse</version>
 
   <name>Netty</name>
   <url>http://netty.io/</url>

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-resolver-dns</artifactId>

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-resolver</artifactId>

--- a/tarball/pom.xml
+++ b/tarball/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-tarball</artifactId>

--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-autobahn</artifactId>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-osgi</artifactId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-testsuite</artifactId>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
   <artifactId>netty-transport-native-epoll</artifactId>
 
@@ -345,7 +345,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.1.13.6.dse</version>
+      <version>4.1.13.7.dse</version>
     </dependency>
   </dependencies>
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Aio.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Aio.java
@@ -28,7 +28,7 @@ public final class Aio {
         Throwable cause = Epoll.unavailabilityCause();
         AIOContext aioContext = null;
         try {
-            aioContext = Native.createAIOContext(1, 1);
+            aioContext = Native.createAIOContext(new AIOContext.Config(1, 1));
         } catch (Throwable t) {
             cause = t;
         } finally {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -52,9 +52,9 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
         this(nThreads, (ThreadFactory) null);
     }
 
-    public EpollEventLoopGroup(int nThreads, boolean aioSupport) {
+    public EpollEventLoopGroup(int nThreads, AIOContext.Config aio) {
         super(nThreads, (ThreadFactory) null, 0, DefaultSelectStrategyFactory.INSTANCE,
-              RejectedExecutionHandlers.reject(), aioSupport);
+              RejectedExecutionHandlers.reject(), aio);
     }
 
     /**
@@ -140,8 +140,8 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
 
     @Override
     protected EventLoop newChild(Executor executor, Object... args) throws Exception {
-        boolean aioSupport = args.length == 3 ? false : (Boolean) args[3];
+        AIOContext.Config aio = args.length == 3 ? null : (AIOContext.Config) args[3];
         return new EpollEventLoop(this, executor, (Integer) args[0],
-                ((SelectStrategyFactory) args[1]).newSelectStrategy(), (RejectedExecutionHandler) args[2], aioSupport);
+                ((SelectStrategyFactory) args[1]).newSelectStrategy(), (RejectedExecutionHandler) args[2], aio);
     }
 }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -24,10 +24,8 @@ import io.netty.channel.unix.FileDescriptor;
 import io.netty.util.internal.ThrowableUtil;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Locale;
 
 import static io.netty.channel.epoll.NativeStaticallyReferencedJniMethods.epollerr;
@@ -191,9 +189,9 @@ public final class Native {
     public static native int offsetofEpollData();
 
     // libaio related
-    static AIOContext createAIOContext(int maxConcurrency, int maxPending) throws IOException {
-        long ctxAddress = createAIOContext0(maxConcurrency);
-        return new AIOContext(ctxAddress, maxConcurrency, maxPending);
+    static AIOContext createAIOContext(AIOContext.Config config) throws IOException {
+        long ctxAddress = createAIOContext0(config.maxConcurrency);
+        return new AIOContext(ctxAddress, config);
     }
 
     static void destroyAIOContext(AIOContext ctx) {

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
   <artifactId>netty-transport-native-kqueue</artifactId>
 

--- a/transport-native-unix-common-tests/pom.xml
+++ b/transport-native-unix-common-tests/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
   <artifactId>netty-transport-native-unix-common-tests</artifactId>
 

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
   <artifactId>netty-transport-native-unix-common</artifactId>
 

--- a/transport-rxtx/pom.xml
+++ b/transport-rxtx/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-transport-rxtx</artifactId>

--- a/transport-sctp/pom.xml
+++ b/transport-sctp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-transport-sctp</artifactId>

--- a/transport-udt/pom.xml
+++ b/transport-udt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-transport-udt</artifactId>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.6.dse</version>
+    <version>4.1.13.7.dse</version>
   </parent>
 
   <artifactId>netty-transport</artifactId>


### PR DESCRIPTION
This is the Netty side patch for [DB-1463](https://datastax.jira.com/browse/DB-1463):

* it moves the event file descriptor from the file channel to the AIO context itself so that we can read without posting an event to the thread that opened the file;
* it replaces the queue sizes with a config object that is specified upon creation of the AIO context so that we can control the AIO queue depth from the apollo code.