### PR TITLE
DB-2993: export used direct memory

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-all</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -69,72 +69,72 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-buffer</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-dns</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-haproxy</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http2</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-memcache</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-mqtt</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-redis</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-smtp</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-socks</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-stomp</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-xml</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-common</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
@@ -144,57 +144,57 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler-proxy</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-rxtx</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-sctp</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-udt</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-example</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
@@ -211,23 +211,23 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>4.1.13.12.dse</version>
+        <version>4.1.13.13.dse</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
     </dependencies>

--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-buffer</artifactId>

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -737,10 +737,10 @@ abstract class PoolArena<T> implements PoolArenaMetric {
                 int pageShifts, int chunkSize) {
             if (directMemoryCacheAlignment == 0) {
                 return new PoolChunk<ByteBuffer>(this,
-                        allocateDirect(chunkSize), pageSize, maxOrder,
+                        PlatformDependent.allocateDirect(chunkSize), pageSize, maxOrder,
                         pageShifts, chunkSize, 0);
             }
-            final ByteBuffer memory = allocateDirect(chunkSize
+            final ByteBuffer memory = PlatformDependent.allocateDirect(chunkSize
                     + directMemoryCacheAlignment);
             return new PoolChunk<ByteBuffer>(this, memory, pageSize,
                     maxOrder, pageShifts, chunkSize,
@@ -751,26 +751,17 @@ abstract class PoolArena<T> implements PoolArenaMetric {
         protected PoolChunk<ByteBuffer> newUnpooledChunk(int capacity) {
             if (directMemoryCacheAlignment == 0) {
                 return new PoolChunk<ByteBuffer>(this,
-                        allocateDirect(capacity), capacity, 0);
+                          PlatformDependent.allocateDirect(capacity), capacity, 0);
             }
-            final ByteBuffer memory = allocateDirect(capacity
+            final ByteBuffer memory = PlatformDependent.allocateDirect(capacity
                     + directMemoryCacheAlignment);
             return new PoolChunk<ByteBuffer>(this, memory, capacity,
                     offsetCacheLine(memory));
         }
 
-        private static ByteBuffer allocateDirect(int capacity) {
-            return PlatformDependent.useDirectBufferNoCleaner() ?
-                    PlatformDependent.allocateDirectNoCleaner(capacity) : ByteBuffer.allocateDirect(capacity);
-        }
-
         @Override
         protected void destroyChunk(PoolChunk<ByteBuffer> chunk) {
-            if (PlatformDependent.useDirectBufferNoCleaner()) {
-                PlatformDependent.freeDirectNoCleaner(chunk.memory);
-            } else {
-                PlatformDependent.freeDirectBuffer(chunk.memory);
-            }
+            PlatformDependent.freeDirectBuffer(chunk.memory);
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -761,7 +761,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
         @Override
         protected void destroyChunk(PoolChunk<ByteBuffer> chunk) {
-            PlatformDependent.freeDirectBuffer(chunk.memory);
+            PlatformDependent.freeDirect(chunk.memory);
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -64,7 +64,7 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
         }
 
         this.alloc = alloc;
-        setByteBuffer(ByteBuffer.allocateDirect(initialCapacity));
+        setByteBuffer(allocateDirect(initialCapacity));
     }
 
     /**
@@ -103,14 +103,14 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
      * Allocate a new direct {@link ByteBuffer} with the given initialCapacity.
      */
     protected ByteBuffer allocateDirect(int initialCapacity) {
-        return ByteBuffer.allocateDirect(initialCapacity);
+        return PlatformDependent.allocateDirectJVM(initialCapacity);
     }
 
     /**
      * Free a direct {@link ByteBuffer}
      */
     protected void freeDirect(ByteBuffer buffer) {
-        PlatformDependent.freeDirectBuffer(buffer);
+        PlatformDependent.freeDirectBufferJVM(buffer);
     }
 
     private void setByteBuffer(ByteBuffer buffer) {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -103,14 +103,14 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
      * Allocate a new direct {@link ByteBuffer} with the given initialCapacity.
      */
     protected ByteBuffer allocateDirect(int initialCapacity) {
-        return PlatformDependent.allocateDirectJVM(initialCapacity);
+        return PlatformDependent.allocateDirectWithCleaner(initialCapacity);
     }
 
     /**
      * Free a direct {@link ByteBuffer}
      */
     protected void freeDirect(ByteBuffer buffer) {
-        PlatformDependent.freeDirectBufferJVM(buffer);
+        PlatformDependent.freeDirectWithCleaner(buffer);
     }
 
     private void setByteBuffer(ByteBuffer buffer) {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
@@ -117,14 +117,14 @@ public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf
      * Allocate a new direct {@link ByteBuffer} with the given initialCapacity.
      */
     protected ByteBuffer allocateDirect(int initialCapacity) {
-        return PlatformDependent.allocateDirectJVM(initialCapacity);
+        return PlatformDependent.allocateDirectWithCleaner(initialCapacity);
     }
 
     /**
      * Free a direct {@link ByteBuffer}
      */
     protected void freeDirect(ByteBuffer buffer) {
-        PlatformDependent.freeDirectBufferJVM(buffer);
+        PlatformDependent.freeDirectWithCleaner(buffer);
     }
 
     final void setByteBuffer(ByteBuffer buffer, boolean tryFree) {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
@@ -117,14 +117,14 @@ public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf
      * Allocate a new direct {@link ByteBuffer} with the given initialCapacity.
      */
     protected ByteBuffer allocateDirect(int initialCapacity) {
-        return ByteBuffer.allocateDirect(initialCapacity);
+        return PlatformDependent.allocateDirectJVM(initialCapacity);
     }
 
     /**
      * Free a direct {@link ByteBuffer}
      */
     protected void freeDirect(ByteBuffer buffer) {
-        PlatformDependent.freeDirectBuffer(buffer);
+        PlatformDependent.freeDirectBufferJVM(buffer);
     }
 
     final void setByteBuffer(ByteBuffer buffer, boolean tryFree) {

--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-codec-dns</artifactId>

--- a/codec-haproxy/pom.xml
+++ b/codec-haproxy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-codec-haproxy</artifactId>

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-codec-http</artifactId>

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-codec-http2</artifactId>

--- a/codec-memcache/pom.xml
+++ b/codec-memcache/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-codec-memcache</artifactId>

--- a/codec-mqtt/pom.xml
+++ b/codec-mqtt/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-codec-mqtt</artifactId>

--- a/codec-redis/pom.xml
+++ b/codec-redis/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-codec-redis</artifactId>

--- a/codec-smtp/pom.xml
+++ b/codec-smtp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-codec-smtp</artifactId>

--- a/codec-socks/pom.xml
+++ b/codec-socks/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-codec-socks</artifactId>

--- a/codec-stomp/pom.xml
+++ b/codec-stomp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-codec-stomp</artifactId>

--- a/codec-xml/pom.xml
+++ b/codec-xml/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-codec-xml</artifactId>

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-codec</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-common</artifactId>

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -549,22 +549,22 @@ public final class PlatformDependent {
     public static ByteBuffer allocateDirect(int capacity) {
         return USE_DIRECT_BUFFER_NO_CLEANER
                 ? PlatformDependent.allocateDirectNoCleaner(capacity)
-                : allocateDirectJVM(capacity);
+                : allocateDirectWithCleaner(capacity);
     }
 
-    public static void freeDirectBuffer(ByteBuffer buffer) {
+    public static void freeDirect(ByteBuffer buffer) {
         if (USE_DIRECT_BUFFER_NO_CLEANER) {
             PlatformDependent.freeDirectNoCleaner(buffer);
         } else {
-            PlatformDependent.freeDirectBufferJVM(buffer);
+            PlatformDependent.freeDirectWithCleaner(buffer);
         }
     }
 
     /**
      * Allocate a new {@link ByteBuffer} with the given {@code capacity}. {@link ByteBuffer}s allocated with
-     * this method <strong>MUST</strong> be deallocated via {@link #freeDirectNoCleaner(ByteBuffer)}.
+     * this method <strong>MUST</strong> be deallocated via {@link #freeDirectWithCleaner(ByteBuffer)}.
      */
-    public static ByteBuffer allocateDirectJVM(int capacity) {
+    public static ByteBuffer allocateDirectWithCleaner(int capacity) {
         incrementMemoryCounter(capacity);
         try {
             return ByteBuffer.allocateDirect(capacity);
@@ -579,7 +579,7 @@ public final class PlatformDependent {
      * Try to deallocate the specified direct {@link ByteBuffer}. Please note this method does nothing if
      * the current platform does not support this operation or the specified buffer is not a direct buffer.
      */
-    public static void freeDirectBufferJVM(ByteBuffer buffer) {
+    public static void freeDirectWithCleaner(ByteBuffer buffer) {
         int capacity = buffer.capacity();
         CLEANER.freeDirectBuffer(buffer);
         decrementMemoryCounter(capacity);

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -147,21 +147,16 @@ public final class PlatformDependent {
 
         if (maxDirectMemory == 0 || !hasUnsafe() || !PlatformDependent0.hasDirectBufferNoCleanerConstructor()) {
             USE_DIRECT_BUFFER_NO_CLEANER = false;
-            DIRECT_MEMORY_COUNTER = null;
         } else {
             USE_DIRECT_BUFFER_NO_CLEANER = true;
             if (maxDirectMemory < 0) {
                 maxDirectMemory = maxDirectMemory0();
-                if (maxDirectMemory <= 0) {
-                    DIRECT_MEMORY_COUNTER = null;
-                } else {
-                    DIRECT_MEMORY_COUNTER = new AtomicLong();
-                }
-            } else {
-                DIRECT_MEMORY_COUNTER = new AtomicLong();
             }
         }
+
+        DIRECT_MEMORY_COUNTER = new AtomicLong();
         DIRECT_MEMORY_LIMIT = maxDirectMemory;
+
         logger.debug("-Dio.netty.maxDirectMemory: {} bytes", maxDirectMemory);
 
         int tryAllocateUninitializedArray =
@@ -353,14 +348,6 @@ public final class PlatformDependent {
      */
     public static <K, V> ConcurrentMap<K, V> newConcurrentHashMap(Map<? extends K, ? extends V> map) {
         return new ConcurrentHashMap<K, V>(map);
-    }
-
-    /**
-     * Try to deallocate the specified direct {@link ByteBuffer}. Please note this method does nothing if
-     * the current platform does not support this operation or the specified buffer is not a direct buffer.
-     */
-    public static void freeDirectBuffer(ByteBuffer buffer) {
-        CLEANER.freeDirectBuffer(buffer);
     }
 
     public static long directBufferAddress(ByteBuffer buffer) {
@@ -559,6 +546,45 @@ public final class PlatformDependent {
         PlatformDependent0.setMemory(address, bytes, value);
     }
 
+    public static ByteBuffer allocateDirect(int capacity) {
+        return USE_DIRECT_BUFFER_NO_CLEANER
+                ? PlatformDependent.allocateDirectNoCleaner(capacity)
+                : allocateDirectJVM(capacity);
+    }
+
+    public static void freeDirectBuffer(ByteBuffer buffer) {
+        if (USE_DIRECT_BUFFER_NO_CLEANER) {
+            PlatformDependent.freeDirectNoCleaner(buffer);
+        } else {
+            PlatformDependent.freeDirectBufferJVM(buffer);
+        }
+    }
+
+    /**
+     * Allocate a new {@link ByteBuffer} with the given {@code capacity}. {@link ByteBuffer}s allocated with
+     * this method <strong>MUST</strong> be deallocated via {@link #freeDirectNoCleaner(ByteBuffer)}.
+     */
+    public static ByteBuffer allocateDirectJVM(int capacity) {
+        incrementMemoryCounter(capacity);
+        try {
+            return ByteBuffer.allocateDirect(capacity);
+        } catch (Throwable e) {
+            decrementMemoryCounter(capacity);
+            throwException(e);
+            return null;
+        }
+    }
+
+    /**
+     * Try to deallocate the specified direct {@link ByteBuffer}. Please note this method does nothing if
+     * the current platform does not support this operation or the specified buffer is not a direct buffer.
+     */
+    public static void freeDirectBufferJVM(ByteBuffer buffer) {
+        int capacity = buffer.capacity();
+        CLEANER.freeDirectBuffer(buffer);
+        decrementMemoryCounter(capacity);
+    }
+
     /**
      * Allocate a new {@link ByteBuffer} with the given {@code capacity}. {@link ByteBuffer}s allocated with
      * this method <strong>MUST</strong> be deallocated via {@link #freeDirectNoCleaner(ByteBuffer)}.
@@ -607,30 +633,30 @@ public final class PlatformDependent {
     }
 
     private static void incrementMemoryCounter(int capacity) {
-        if (DIRECT_MEMORY_COUNTER != null) {
-            for (;;) {
-                long usedMemory = DIRECT_MEMORY_COUNTER.get();
-                long newUsedMemory = usedMemory + capacity;
-                if (newUsedMemory > DIRECT_MEMORY_LIMIT) {
-                    throw new OutOfDirectMemoryError("failed to allocate " + capacity
-                            + " byte(s) of direct memory (used: " + usedMemory + ", max: " + DIRECT_MEMORY_LIMIT + ')');
-                }
-                if (DIRECT_MEMORY_COUNTER.compareAndSet(usedMemory, newUsedMemory)) {
-                    break;
-                }
+        for (;;) {
+            long usedMemory = DIRECT_MEMORY_COUNTER.get();
+            long newUsedMemory = usedMemory + capacity;
+            if (DIRECT_MEMORY_LIMIT > 0 && newUsedMemory > DIRECT_MEMORY_LIMIT) {
+                throw new OutOfDirectMemoryError("failed to allocate " + capacity
+                        + " byte(s) of direct memory (used: " + usedMemory + ", max: " + DIRECT_MEMORY_LIMIT + ')');
+            }
+            if (DIRECT_MEMORY_COUNTER.compareAndSet(usedMemory, newUsedMemory)) {
+                break;
             }
         }
     }
 
     private static void decrementMemoryCounter(int capacity) {
-        if (DIRECT_MEMORY_COUNTER != null) {
-            long usedMemory = DIRECT_MEMORY_COUNTER.addAndGet(-capacity);
-            assert usedMemory >= 0;
-        }
+        long usedMemory = DIRECT_MEMORY_COUNTER.addAndGet(-capacity);
+        assert usedMemory >= 0 : "Used memory is negative: " + usedMemory;
     }
 
     public static boolean useDirectBufferNoCleaner() {
         return USE_DIRECT_BUFFER_NO_CLEANER;
+    }
+
+    public static long usedDirectMemory() {
+        return DIRECT_MEMORY_COUNTER.get();
     }
 
     /**

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-example</artifactId>

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-handler-proxy</artifactId>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-handler</artifactId>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-microbench</artifactId>

--- a/microbench/src/main/java/io/netty/microbench/handler/ssl/AbstractSslEngineBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/handler/ssl/AbstractSslEngineBenchmark.java
@@ -109,12 +109,12 @@ public class AbstractSslEngineBenchmark extends AbstractMicrobenchmark {
         DIRECT {
             @Override
             ByteBuffer newBuffer(int size) {
-                return ByteBuffer.allocateDirect(size);
+                return PlatformDependent.allocateDirectJVM(size);
             }
 
             @Override
             void freeBuffer(ByteBuffer buffer) {
-                PlatformDependent.freeDirectBuffer(buffer);
+                PlatformDependent.freeDirectBufferJVM(buffer);
             }
         };
 

--- a/microbench/src/main/java/io/netty/microbench/handler/ssl/AbstractSslEngineBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/handler/ssl/AbstractSslEngineBenchmark.java
@@ -109,12 +109,12 @@ public class AbstractSslEngineBenchmark extends AbstractMicrobenchmark {
         DIRECT {
             @Override
             ByteBuffer newBuffer(int size) {
-                return PlatformDependent.allocateDirectJVM(size);
+                return PlatformDependent.allocateDirectWithCleaner(size);
             }
 
             @Override
             void freeBuffer(ByteBuffer buffer) {
-                PlatformDependent.freeDirectBufferJVM(buffer);
+                PlatformDependent.freeDirectWithCleaner(buffer);
             }
         };
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <groupId>io.netty</groupId>
   <artifactId>netty-parent</artifactId>
   <packaging>pom</packaging>
-  <version>4.1.13.12.dse</version>
+  <version>4.1.13.13.dse</version>
 
   <name>Netty</name>
   <url>http://netty.io/</url>

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-resolver-dns</artifactId>

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-resolver</artifactId>

--- a/tarball/pom.xml
+++ b/tarball/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-tarball</artifactId>

--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-autobahn</artifactId>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-osgi</artifactId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-testsuite</artifactId>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
   <artifactId>netty-transport-native-epoll</artifactId>
 
@@ -345,7 +345,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.1.13.12.dse</version>
+      <version>4.1.13.13.dse</version>
     </dependency>
   </dependencies>
 

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
   <artifactId>netty-transport-native-kqueue</artifactId>
 

--- a/transport-native-unix-common-tests/pom.xml
+++ b/transport-native-unix-common-tests/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
   <artifactId>netty-transport-native-unix-common-tests</artifactId>
 

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
   <artifactId>netty-transport-native-unix-common</artifactId>
 

--- a/transport-rxtx/pom.xml
+++ b/transport-rxtx/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-transport-rxtx</artifactId>

--- a/transport-sctp/pom.xml
+++ b/transport-sctp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-transport-sctp</artifactId>

--- a/transport-udt/pom.xml
+++ b/transport-udt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-transport-udt</artifactId>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.13.12.dse</version>
+    <version>4.1.13.13.dse</version>
   </parent>
 
   <artifactId>netty-transport</artifactId>


### PR DESCRIPTION
I redirected the JVM NIO direct buffer allocations to `PlatformDependent` so long as these buffers were  cleaned via `PlatformDependent`.

 I've also  changed `PlatformDependent` to measure allocated memory even when using the JVM NIO direct allocations. I then exported the memory allocated with `PlatformDependent.usedDirectMemory()`. The idea is to read this value in our own native memory metrics.

@sbtourist or @tjake would you be able to review?

cc @snazy 