### PR TITLE
DSP-19407 after upgrade review remarks

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -38,7 +38,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
                 }
             };
 
-    PriorityQueue<ScheduledFutureTask<?>> scheduledTaskQueue;
+    protected PriorityQueue<ScheduledFutureTask<?>> scheduledTaskQueue;
 
     protected AbstractScheduledEventExecutor() {
     }


### PR DESCRIPTION
Reason for reverting incrementMemoryCounter implementation (from
Sergio's comment):

"..moving from a CAS loop to the double addAndGet() might be faster, but
by doing so, a single big-ish allocation which goes over the limit
could cause concurrent small allocations to fail as well before the
memory limit is brought back below threshold via
DIRECT_MEMORY_COUNTER.addAndGet(-capacity)"