### PR TITLE
DB-4068 cherry-pick upstream HttpRequest/ObjectDecoder fixes (4.1.25/bdp 6.{0,7,8})

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-all</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>io.netty</groupId>
   <artifactId>netty-bom</artifactId>
-  <version>4.1.25.dse</version>
+  <version>4.1.25.7.dse</version>
   <packaging>pom</packaging>
 
   <name>Netty/BOM</name>
@@ -49,7 +49,6 @@
     <url>https://github.com/netty/netty</url>
     <connection>scm:git:git://github.com/netty/netty.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/netty/netty.git</developerConnection>
-    <tag>netty-4.1.25.dse</tag>
   </scm>
 
   <developers>
@@ -69,72 +68,72 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-buffer</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-dns</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-haproxy</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http2</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-memcache</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-mqtt</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-redis</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-smtp</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-socks</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-stomp</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-xml</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-common</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
@@ -144,90 +143,90 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler-proxy</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-rxtx</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-sctp</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-udt</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-example</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>4.1.25.6.dse</version>
+        <version>4.1.25.7.dse</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
     </dependencies>

--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-buffer</artifactId>

--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-dns</artifactId>

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsRecord.java
@@ -21,6 +21,7 @@ import io.netty.util.internal.UnstableApi;
 import java.net.IDN;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
  * A skeletal implementation of {@link DnsRecord}.
@@ -62,9 +63,7 @@ public abstract class AbstractDnsRecord implements DnsRecord {
      * @param timeToLive the TTL value of the record
      */
     protected AbstractDnsRecord(String name, DnsRecordType type, int dnsClass, long timeToLive) {
-        if (timeToLive < 0) {
-            throw new IllegalArgumentException("timeToLive: " + timeToLive + " (expected: >= 0)");
-        }
+        checkPositiveOrZero(timeToLive, "timeToLive");
         // Convert to ASCII which will also check that the length is not too big.
         // See:
         //   - https://github.com/netty/netty/issues/4937

--- a/codec-haproxy/pom.xml
+++ b/codec-haproxy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-haproxy</artifactId>

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-http</artifactId>

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -372,8 +372,7 @@ public class DefaultHttpHeaders extends HttpHeaders {
         default:
             // Check to see if the character is not an ASCII character, or invalid
             if (value < 0) {
-                throw new IllegalArgumentException("a header name cannot contain non-ASCII character: " +
-                        value);
+                throw new IllegalArgumentException("a header name cannot contain non-ASCII character: " + value);
             }
         }
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -575,7 +575,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         }
         if (line.length() > 0) {
             do {
-                char firstChar = line.charAt(0);
+                char firstChar = line.charAtUnsafe(0);
                 if (name != null && (firstChar == ' ' || firstChar == '\t')) {
                     //please do not make one line from below code
                     //as it breaks +XX:OptimizeStringConcat optimization
@@ -643,7 +643,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             trailer = this.trailer = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, validateHeaders);
         }
         while (line.length() > 0) {
-            char firstChar = line.charAt(0);
+            char firstChar = line.charAtUnsafe(0);
             if (lastHeader != null && (firstChar == ' ' || firstChar == '\t')) {
                 List<String> current = trailer.trailingHeaders().getAll(lastHeader);
                 if (!current.isEmpty()) {
@@ -727,14 +727,14 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
         nameStart = findNonWhitespace(sb, 0);
         for (nameEnd = nameStart; nameEnd < length; nameEnd ++) {
-            char ch = sb.charAt(nameEnd);
+            char ch = sb.charAtUnsafe(nameEnd);
             if (ch == ':' || Character.isWhitespace(ch)) {
                 break;
             }
         }
 
         for (colonEnd = nameEnd; colonEnd < length; colonEnd ++) {
-            if (sb.charAt(colonEnd) == ':') {
+            if (sb.charAtUnsafe(colonEnd) == ':') {
                 colonEnd ++;
                 break;
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -600,23 +600,61 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         if (name != null) {
             headers.add(name, value);
         }
+
         // reset name and value fields
         name = null;
         value = null;
 
-        State nextState;
+        List<String> values = headers.getAll(HttpHeaderNames.CONTENT_LENGTH);
+        int contentLengthValuesCount = values.size();
+
+        if (contentLengthValuesCount > 0) {
+            // Guard against multiple Content-Length headers as stated in
+            // https://tools.ietf.org/html/rfc7230#section-3.3.2:
+            //
+            // If a message is received that has multiple Content-Length header
+            //   fields with field-values consisting of the same decimal value, or a
+            //   single Content-Length header field with a field value containing a
+            //   list of identical decimal values (e.g., "Content-Length: 42, 42"),
+            //   indicating that duplicate Content-Length header fields have been
+            //   generated or combined by an upstream message processor, then the
+            //   recipient MUST either reject the message as invalid or replace the
+            //   duplicated field-values with a single valid Content-Length field
+            //   containing that decimal value prior to determining the message body
+            //   length or forwarding the message.
+            if (contentLengthValuesCount > 1 && message.protocolVersion() == HttpVersion.HTTP_1_1) {
+                throw new IllegalArgumentException("Multiple Content-Length headers found");
+            }
+            contentLength = Long.parseLong(values.get(0));
+        }
 
         if (isContentAlwaysEmpty(message)) {
             HttpUtil.setTransferEncodingChunked(message, false);
-            nextState = State.SKIP_CONTROL_CHARS;
+            return State.SKIP_CONTROL_CHARS;
         } else if (HttpUtil.isTransferEncodingChunked(message)) {
-            nextState = State.READ_CHUNK_SIZE;
+            // See https://tools.ietf.org/html/rfc7230#section-3.3.3
+            //
+            //       If a message is received with both a Transfer-Encoding and a
+            //       Content-Length header field, the Transfer-Encoding overrides the
+            //       Content-Length.  Such a message might indicate an attempt to
+            //       perform request smuggling (Section 9.5) or response splitting
+            //       (Section 9.4) and ought to be handled as an error.  A sender MUST
+            //       remove the received Content-Length field prior to forwarding such
+            //       a message downstream.
+            //
+            // This is also what http_parser does:
+            // https://github.com/nodejs/http-parser/blob/v2.9.2/http_parser.c#L1769
+            if (contentLengthValuesCount > 0 && message.protocolVersion() == HttpVersion.HTTP_1_1) {
+                throw new IllegalArgumentException(
+                        "Both 'Content-Length: " + contentLength + "' and 'Transfer-Encoding: chunked' found");
+            }
+
+            return State.READ_CHUNK_SIZE;
         } else if (contentLength() >= 0) {
-            nextState = State.READ_FIXED_LENGTH_CONTENT;
+            return State.READ_FIXED_LENGTH_CONTENT;
         } else {
-            nextState = State.READ_VARIABLE_LENGTH_CONTENT;
+            return State.READ_VARIABLE_LENGTH_CONTENT;
         }
-        return nextState;
     }
 
     private long contentLength() {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -747,6 +747,11 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             }
         }
 
+        if (nameEnd == length) {
+            // There was no colon present at all.
+            throw new IllegalArgumentException("No colon found");
+        }
+
         for (colonEnd = nameEnd; colonEnd < length; colonEnd ++) {
             if (sb.charAtUnsafe(colonEnd) == ':') {
                 colonEnd ++;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -728,7 +728,21 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         nameStart = findNonWhitespace(sb, 0);
         for (nameEnd = nameStart; nameEnd < length; nameEnd ++) {
             char ch = sb.charAtUnsafe(nameEnd);
-            if (ch == ':' || Character.isWhitespace(ch)) {
+            // https://tools.ietf.org/html/rfc7230#section-3.2.4
+            //
+            // No whitespace is allowed between the header field-name and colon. In
+            // the past, differences in the handling of such whitespace have led to
+            // security vulnerabilities in request routing and response handling. A
+            // server MUST reject any received request message that contains
+            // whitespace between a header field-name and colon with a response code
+            // of 400 (Bad Request). A proxy MUST remove any such whitespace from a
+            // response message before forwarding the message downstream.
+            if (ch == ':' ||
+                    // In case of decoding a request we will just continue processing and header validation
+                    // is done in the DefaultHttpHeaders implementation.
+                    //
+                    // In the case of decoding a response we will "skip" the whitespace.
+                    (!isDecodingRequest() && Character.isWhitespace(ch))) {
                 break;
             }
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http;
 
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -168,21 +170,10 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     protected HttpObjectDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
             boolean chunkedSupported, boolean validateHeaders, int initialBufferSize) {
-        if (maxInitialLineLength <= 0) {
-            throw new IllegalArgumentException(
-                    "maxInitialLineLength must be a positive integer: " +
-                     maxInitialLineLength);
-        }
-        if (maxHeaderSize <= 0) {
-            throw new IllegalArgumentException(
-                    "maxHeaderSize must be a positive integer: " +
-                    maxHeaderSize);
-        }
-        if (maxChunkSize <= 0) {
-            throw new IllegalArgumentException(
-                    "maxChunkSize must be a positive integer: " +
-                    maxChunkSize);
-        }
+        checkPositive(maxInitialLineLength, "maxInitialLineLength");
+        checkPositive(maxHeaderSize, "maxHeaderSize");
+        checkPositive(maxChunkSize, "maxChunkSize");
+
         AppendableCharSequence seq = new AppendableCharSequence(initialBufferSize);
         lineParser = new LineParser(seq, maxInitialLineLength);
         headerParser = new HeaderParser(seq, maxHeaderSize);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
@@ -22,6 +22,7 @@ import io.netty.util.CharsetUtil;
 
 import static io.netty.handler.codec.http.HttpConstants.SP;
 import static io.netty.util.ByteProcessor.FIND_ASCII_SPACE;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 import static java.lang.Integer.parseInt;
 
 /**
@@ -538,10 +539,7 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
     }
 
     private HttpResponseStatus(int code, String reasonPhrase, boolean bytes) {
-        if (code < 0) {
-            throw new IllegalArgumentException(
-                    "code: " + code + " (expected: 0+)");
-        }
+        checkPositiveOrZero(code, "code");
 
         if (reasonPhrase == null) {
             throw new NullPointerException("reasonPhrase");

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http;
 
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.util.CharsetUtil;
 
@@ -165,12 +167,8 @@ public class HttpVersion implements Comparable<HttpVersion> {
             }
         }
 
-        if (majorVersion < 0) {
-            throw new IllegalArgumentException("negative majorVersion");
-        }
-        if (minorVersion < 0) {
-            throw new IllegalArgumentException("negative minorVersion");
-        }
+        checkPositiveOrZero(majorVersion, "majorVersion");
+        checkPositiveOrZero(minorVersion, "minorVersion");
 
         this.protocolName = protocolName;
         this.majorVersion = majorVersion;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpData.java
@@ -128,8 +128,7 @@ public abstract class AbstractMemoryHttpData extends AbstractHttpData {
         }
         long newsize = file.length();
         if (newsize > Integer.MAX_VALUE) {
-            throw new IllegalArgumentException(
-                    "File too big to be loaded in memory");
+            throw new IllegalArgumentException("File too big to be loaded in memory");
         }
         checkSize(newsize);
         FileInputStream inputStream = new FileInputStream(file);

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyGoAwayFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyGoAwayFrame.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.spdy;
 
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
 import io.netty.util.internal.StringUtil;
 
 /**
@@ -62,10 +64,7 @@ public class DefaultSpdyGoAwayFrame implements SpdyGoAwayFrame {
 
     @Override
     public SpdyGoAwayFrame setLastGoodStreamId(int lastGoodStreamId) {
-        if (lastGoodStreamId < 0) {
-            throw new IllegalArgumentException("Last-good-stream-ID"
-                    + " cannot be negative: " + lastGoodStreamId);
-        }
+        checkPositiveOrZero(lastGoodStreamId, "lastGoodStreamId");
         this.lastGoodStreamId = lastGoodStreamId;
         return this;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyStreamFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyStreamFrame.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.spdy;
 
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+
 /**
  * The default {@link SpdyStreamFrame} implementation.
  */
@@ -39,10 +41,7 @@ public abstract class DefaultSpdyStreamFrame implements SpdyStreamFrame {
 
     @Override
     public SpdyStreamFrame setStreamId(int streamId) {
-        if (streamId <= 0) {
-            throw new IllegalArgumentException(
-                    "Stream-ID must be positive: " + streamId);
-        }
+        checkPositive(streamId, "streamId");
         this.streamId = streamId;
         return this;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdySynReplyFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdySynReplyFrame.java
@@ -20,8 +20,7 @@ import io.netty.util.internal.StringUtil;
 /**
  * The default {@link SpdySynReplyFrame} implementation.
  */
-public class DefaultSpdySynReplyFrame extends DefaultSpdyHeadersFrame
-        implements SpdySynReplyFrame {
+public class DefaultSpdySynReplyFrame extends DefaultSpdyHeadersFrame implements SpdySynReplyFrame {
 
     /**
      * Creates a new instance.

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdySynStreamFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdySynStreamFrame.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.spdy;
 
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
 import io.netty.util.internal.StringUtil;
 
 /**
@@ -77,11 +79,7 @@ public class DefaultSpdySynStreamFrame extends DefaultSpdyHeadersFrame
 
     @Override
     public SpdySynStreamFrame setAssociatedStreamId(int associatedStreamId) {
-        if (associatedStreamId < 0) {
-            throw new IllegalArgumentException(
-                    "Associated-To-Stream-ID cannot be negative: " +
-                    associatedStreamId);
-        }
+        checkPositiveOrZero(associatedStreamId, "associatedStreamId");
         this.associatedStreamId = associatedStreamId;
         return this;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyWindowUpdateFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyWindowUpdateFrame.java
@@ -15,6 +15,9 @@
  */
 package io.netty.handler.codec.spdy;
 
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
 import io.netty.util.internal.StringUtil;
 
 /**
@@ -43,10 +46,7 @@ public class DefaultSpdyWindowUpdateFrame implements SpdyWindowUpdateFrame {
 
     @Override
     public SpdyWindowUpdateFrame setStreamId(int streamId) {
-        if (streamId < 0) {
-            throw new IllegalArgumentException(
-                    "Stream-ID cannot be negative: " + streamId);
-        }
+        checkPositiveOrZero(streamId, "streamId");
         this.streamId = streamId;
         return this;
     }
@@ -58,11 +58,7 @@ public class DefaultSpdyWindowUpdateFrame implements SpdyWindowUpdateFrame {
 
     @Override
     public SpdyWindowUpdateFrame setDeltaWindowSize(int deltaWindowSize) {
-        if (deltaWindowSize <= 0) {
-            throw new IllegalArgumentException(
-                    "Delta-Window-Size must be positive: " +
-                    deltaWindowSize);
-        }
+        checkPositive(deltaWindowSize, "deltaWindowSize");
         this.deltaWindowSize = deltaWindowSize;
         return this;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
@@ -38,6 +38,8 @@ import static io.netty.handler.codec.spdy.SpdyCodecUtil.getSignedInt;
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.getUnsignedInt;
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.getUnsignedMedium;
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.getUnsignedShort;
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
@@ -95,10 +97,7 @@ public class SpdyFrameDecoder {
         if (delegate == null) {
             throw new NullPointerException("delegate");
         }
-        if (maxChunkSize <= 0) {
-            throw new IllegalArgumentException(
-                    "maxChunkSize must be a positive integer: " + maxChunkSize);
-        }
+        checkPositive(maxChunkSize, "maxChunkSize");
         this.spdyVersion = spdyVersion.getVersion();
         this.delegate = delegate;
         this.maxChunkSize = maxChunkSize;

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.netty.handler.codec.spdy.SpdyHeaders.HttpNames.*;
+import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 /**
  * Decodes {@link SpdySynStreamFrame}s, {@link SpdySynReplyFrame}s,
@@ -103,10 +104,7 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
         if (version == null) {
             throw new NullPointerException("version");
         }
-        if (maxContentLength <= 0) {
-            throw new IllegalArgumentException(
-                    "maxContentLength must be a positive integer: " + maxContentLength);
-        }
+        checkPositive(maxContentLength, "maxContentLength");
         spdyVersion = version.getVersion();
         this.maxContentLength = maxContentLength;
         this.messageMap = messageMap;

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.SPDY_SESSION_STREAM_ID;
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.isServerId;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
  * Manages streams within a SPDY session.
@@ -77,16 +78,14 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
     }
 
     public void setSessionReceiveWindowSize(int sessionReceiveWindowSize) {
-      if (sessionReceiveWindowSize < 0) {
-        throw new IllegalArgumentException("sessionReceiveWindowSize");
-      }
-      // This will not send a window update frame immediately.
-      // If this value increases the allowed receive window size,
-      // a WINDOW_UPDATE frame will be sent when only half of the
-      // session window size remains during data frame processing.
-      // If this value decreases the allowed receive window size,
-      // the window will be reduced as data frames are processed.
-      initialSessionReceiveWindowSize = sessionReceiveWindowSize;
+        checkPositiveOrZero(sessionReceiveWindowSize, "sessionReceiveWindowSize");
+        // This will not send a window update frame immediately.
+        // If this value increases the allowed receive window size,
+        // a WINDOW_UPDATE frame will be sent when only half of the
+        // session window size remains during data frame processing.
+        // If this value decreases the allowed receive window size,
+        // the window will be reduced as data frames are processed.
+        initialSessionReceiveWindowSize = sessionReceiveWindowSize;
     }
 
     @Override

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -320,4 +320,18 @@ public class HttpRequestDecoderTest {
         assertTrue(request.decoderResult().cause() instanceof TooLongFrameException);
         assertFalse(channel.finish());
     }
+
+    @Test
+    public void testWhitespace() {
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        String requestStr = "GET /some/path HTTP/1.1\r\n" +
+                "Transfer-Encoding : chunked\r\n" +
+                "Host: netty.io\n\r\n";
+
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertTrue(request.decoderResult().isFailure());
+        assertTrue(request.decoderResult().cause() instanceof IllegalArgumentException);
+        assertFalse(channel.finish());
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -334,4 +334,20 @@ public class HttpRequestDecoderTest {
         assertTrue(request.decoderResult().cause() instanceof IllegalArgumentException);
         assertFalse(channel.finish());
     }
+
+    @Test
+    public void testHeaderWithNoValueAndMissingColon() {
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        String requestStr = "GET /some/path HTTP/1.1\r\n" +
+                "Content-Length: 0\r\n" +
+                "Host:\r\n" +
+                "netty.io\r\n\r\n";
+
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        System.err.println(request.headers().names().toString());
+        assertTrue(request.decoderResult().isFailure());
+        assertTrue(request.decoderResult().cause() instanceof IllegalArgumentException);
+        assertFalse(channel.finish());
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -323,29 +323,75 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testWhitespace() {
-        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                 "Transfer-Encoding : chunked\r\n" +
                 "Host: netty.io\n\r\n";
-
-        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
-        HttpRequest request = channel.readInbound();
-        assertTrue(request.decoderResult().isFailure());
-        assertTrue(request.decoderResult().cause() instanceof IllegalArgumentException);
-        assertFalse(channel.finish());
+        testInvalidHeaders0(requestStr);
     }
 
     @Test
     public void testHeaderWithNoValueAndMissingColon() {
-        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                 "Content-Length: 0\r\n" +
                 "Host:\r\n" +
                 "netty.io\r\n\r\n";
+        testInvalidHeaders0(requestStr);
+    }
 
+    @Test
+    public void testMultipleContentLengthHeaders() {
+        String requestStr = "GET /some/path HTTP/1.1\r\n" +
+                "Content-Length: 1\r\n" +
+                "Content-Length: 0\r\n\r\n" +
+                "b";
+        testInvalidHeaders0(requestStr);
+    }
+
+    @Test
+    public void testMultipleContentLengthHeaders2() {
+        String requestStr = "GET /some/path HTTP/1.1\r\n" +
+                "Content-Length: 1\r\n" +
+                "Connection: close\r\n" +
+                "Content-Length: 0\r\n\r\n" +
+                "b";
+        testInvalidHeaders0(requestStr);
+    }
+
+    @Test
+    public void testContentLengthHeaderWithCommaValue() {
+        String requestStr = "GET /some/path HTTP/1.1\r\n" +
+                "Content-Length: 1,1\r\n\r\n" +
+                "b";
+        testInvalidHeaders0(requestStr);
+    }
+
+    @Test
+    public void testMultipleContentLengthHeadersWithFolding() {
+        String requestStr = "POST / HTTP/1.1\r\n" +
+                "Host: example.com\r\n" +
+                "Connection: close\r\n" +
+                "Content-Length: 5\r\n" +
+                "Content-Length:\r\n" +
+                "\t6\r\n\r\n" +
+                "123456";
+        testInvalidHeaders0(requestStr);
+    }
+
+    @Test
+    public void testContentLengthHeaderAndChunked() {
+        String requestStr = "POST / HTTP/1.1\r\n" +
+                "Host: example.com\r\n" +
+                "Connection: close\r\n" +
+                "Content-Length: 5\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "0\r\n\r\n";
+        testInvalidHeaders0(requestStr);
+    }
+
+    private static void testInvalidHeaders0(String requestStr) {
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
         HttpRequest request = channel.readInbound();
-        System.err.println(request.headers().names().toString());
         assertTrue(request.decoderResult().isFailure());
         assertTrue(request.decoderResult().cause() instanceof IllegalArgumentException);
         assertFalse(channel.finish());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -712,4 +712,19 @@ public class HttpResponseDecoderTest {
 
         assertFalse(channel.finish());
     }
+
+    @Test
+    public void testWhitespace() {
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
+        String requestStr = "HTTP/1.1 200 OK\r\n" +
+                "Transfer-Encoding : chunked\r\n" +
+                "Host: netty.io\n\r\n";
+
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpResponse response = channel.readInbound();
+        assertFalse(response.decoderResult().isFailure());
+        assertEquals(HttpHeaderValues.CHUNKED.toString(), response.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
+        assertEquals("netty.io", response.headers().get(HttpHeaderNames.HOST));
+        assertFalse(channel.finish());
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -683,4 +683,33 @@ public class HttpResponseDecoderTest {
         assertThat(message.decoderResult().cause(), instanceOf(PrematureChannelClosureException.class));
         assertNull(channel.readInbound());
     }
+
+    @Test
+    public void testTrailerWithEmptyLineInSeparateBuffer() {
+        HttpResponseDecoder decoder = new HttpResponseDecoder();
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        String headers = "HTTP/1.1 200 OK\r\n"
+                + "Transfer-Encoding: chunked\r\n"
+                + "Trailer: My-Trailer\r\n";
+        assertFalse(channel.writeInbound(Unpooled.copiedBuffer(headers.getBytes(CharsetUtil.US_ASCII))));
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer("\r\n".getBytes(CharsetUtil.US_ASCII))));
+
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer("0\r\n", CharsetUtil.US_ASCII)));
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer("My-Trailer: 42\r\n", CharsetUtil.US_ASCII)));
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer("\r\n", CharsetUtil.US_ASCII)));
+
+        HttpResponse response = channel.readInbound();
+        assertEquals(2, response.headers().size());
+        assertEquals("chunked", response.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
+        assertEquals("My-Trailer", response.headers().get(HttpHeaderNames.TRAILER));
+
+        LastHttpContent lastContent = channel.readInbound();
+        assertEquals(1, lastContent.trailingHeaders().size());
+        assertEquals("42", lastContent.trailingHeaders().get("My-Trailer"));
+        assertEquals(0, lastContent.content().readableBytes());
+        lastContent.release();
+
+        assertFalse(channel.finish());
+    }
 }

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-http2</artifactId>

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -30,6 +30,7 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGH
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Math.min;
 
@@ -525,9 +526,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
 
         FlowControlledBase(final Http2Stream stream, int padding, boolean endOfStream,
                 final ChannelPromise promise) {
-            if (padding < 0) {
-                throw new IllegalArgumentException("padding must be >= 0");
-            }
+            checkPositiveOrZero(padding, "padding");
             this.padding = padding;
             this.endOfStream = endOfStream;
             this.stream = stream;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -61,6 +61,8 @@ import static io.netty.handler.codec.http2.Http2FrameTypes.RST_STREAM;
 import static io.netty.handler.codec.http2.Http2FrameTypes.SETTINGS;
 import static io.netty.handler.codec.http2.Http2FrameTypes.WINDOW_UPDATE;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 
@@ -614,15 +616,11 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
     }
 
     private static void verifyStreamId(int streamId, String argumentName) {
-        if (streamId <= 0) {
-            throw new IllegalArgumentException(argumentName + " must be > 0");
-        }
+        checkPositive(streamId, "streamId");
     }
 
     private static void verifyStreamOrConnectionId(int streamId, String argumentName) {
-        if (streamId < 0) {
-            throw new IllegalArgumentException(argumentName + " must be >= 0");
-        }
+        checkPositiveOrZero(streamId, "streamId");
     }
 
     private static void verifyWeight(short weight) {
@@ -638,9 +636,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
     }
 
     private static void verifyWindowSizeIncrement(int windowSizeIncrement) {
-        if (windowSizeIncrement < 0) {
-            throw new IllegalArgumentException("WindowSizeIncrement must be >= 0");
-        }
+        checkPositiveOrZero(windowSizeIncrement, "windowSizeIncrement");
     }
 
     private static void verifyPingPayload(ByteBuf data) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http2;
 
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.buffer.Unpooled;
@@ -98,9 +100,7 @@ public final class DefaultHttp2GoAwayFrame extends DefaultByteBufHolder implemen
 
     @Override
     public Http2GoAwayFrame setExtraStreamIds(int extraStreamIds) {
-        if (extraStreamIds < 0) {
-            throw new IllegalArgumentException("extraStreamIds must be non-negative");
-        }
+        checkPositiveOrZero(extraStreamIds, "extraStreamIds");
         this.extraStreamIds = extraStreamIds;
         return this;
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
@@ -24,6 +24,7 @@ import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static io.netty.handler.codec.http2.Http2Exception.streamError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import io.netty.buffer.ByteBuf;
@@ -173,9 +174,7 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
     @Override
     public boolean consumeBytes(Http2Stream stream, int numBytes) throws Http2Exception {
         assert ctx != null && ctx.executor().inEventLoop();
-        if (numBytes < 0) {
-            throw new IllegalArgumentException("numBytes must not be negative");
-        }
+        checkPositiveOrZero(numBytes, "numBytes");
         if (numBytes == 0) {
             return false;
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -31,6 +31,7 @@ import static io.netty.handler.codec.http2.Http2Error.STREAM_CLOSED;
 import static io.netty.handler.codec.http2.Http2Exception.streamError;
 import static io.netty.handler.codec.http2.Http2Stream.State.HALF_CLOSED_LOCAL;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 
@@ -635,9 +636,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
         }
 
         void initialWindowSize(int newWindowSize) throws Http2Exception {
-            if (newWindowSize < 0) {
-                throw new IllegalArgumentException("Invalid initial window size: " + newWindowSize);
-            }
+            checkPositiveOrZero(newWindowSize, "newWindowSize");
 
             final int delta = newWindowSize - initialWindowSize;
             initialWindowSize = newWindowSize;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
@@ -33,6 +33,7 @@ import static io.netty.handler.codec.http.HttpHeaderValues.X_GZIP;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.streamError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
  * A HTTP2 frame listener that will decompress data frames according to the {@code content-encoding} header for each
@@ -398,9 +399,7 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
          * @return The number of pre-decompressed bytes that have been consumed.
          */
         int consumeBytes(int streamId, int decompressedBytes) throws Http2Exception {
-            if (decompressedBytes < 0) {
-                throw new IllegalArgumentException("decompressedBytes must not be negative: " + decompressedBytes);
-            }
+            checkPositiveOrZero(decompressedBytes, "decompressedBytes");
             if (decompressed - decompressedBytes < 0) {
                 throw streamError(streamId, INTERNAL_ERROR,
                         "Attempting to return too many bytes for stream %d. decompressed: %d " +

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/UniformStreamByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/UniformStreamByteDistributor.java
@@ -24,6 +24,7 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.streamableBytes;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkPositive;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 
@@ -72,9 +73,7 @@ public final class UniformStreamByteDistributor implements StreamByteDistributor
      * Must be > 0.
      */
     public void minAllocationChunk(int minAllocationChunk) {
-        if (minAllocationChunk <= 0) {
-            throw new IllegalArgumentException("minAllocationChunk must be > 0");
-        }
+        checkPositive(minAllocationChunk, "minAllocationChunk");
         this.minAllocationChunk = minAllocationChunk;
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
@@ -37,6 +37,8 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGH
 import static io.netty.handler.codec.http2.Http2CodecUtil.streamableBytes;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -96,9 +98,8 @@ public final class WeightedFairQueueByteDistributor implements StreamByteDistrib
     }
 
     public WeightedFairQueueByteDistributor(Http2Connection connection, int maxStateOnlySize) {
-        if (maxStateOnlySize < 0) {
-            throw new IllegalArgumentException("maxStateOnlySize: " + maxStateOnlySize + " (expected: >0)");
-        } else if (maxStateOnlySize == 0) {
+        checkPositiveOrZero(maxStateOnlySize, "maxStateOnlySize");
+        if (maxStateOnlySize == 0) {
             stateOnlyMap = IntCollections.emptyMap();
             stateOnlyRemovalQueue = EmptyPriorityQueue.instance();
         } else {
@@ -281,9 +282,7 @@ public final class WeightedFairQueueByteDistributor implements StreamByteDistrib
      * @param allocationQuantum the amount of bytes that will be allocated to each stream. Must be &gt; 0.
      */
     public void allocationQuantum(int allocationQuantum) {
-        if (allocationQuantum <= 0) {
-            throw new IllegalArgumentException("allocationQuantum must be > 0");
-        }
+        checkPositive(allocationQuantum, "allocationQuantum");
         this.allocationQuantum = allocationQuantum;
     }
 

--- a/codec-memcache/pom.xml
+++ b/codec-memcache/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-memcache</artifactId>

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.memcache.binary;
 
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -59,9 +61,7 @@ public abstract class AbstractBinaryMemcacheDecoder<M extends BinaryMemcacheMess
      * @param chunkSize the maximum chunk size of the payload.
      */
     protected AbstractBinaryMemcacheDecoder(int chunkSize) {
-        if (chunkSize < 0) {
-            throw new IllegalArgumentException("chunkSize must be a positive integer: " + chunkSize);
-        }
+        checkPositiveOrZero(chunkSize, "chunkSize");
 
         this.chunkSize = chunkSize;
     }

--- a/codec-mqtt/pom.xml
+++ b/codec-mqtt/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-mqtt</artifactId>

--- a/codec-redis/pom.xml
+++ b/codec-redis/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-redis</artifactId>

--- a/codec-smtp/pom.xml
+++ b/codec-smtp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-smtp</artifactId>

--- a/codec-socks/pom.xml
+++ b/codec-socks/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-socks</artifactId>

--- a/codec-stomp/pom.xml
+++ b/codec-stomp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-stomp</artifactId>

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
@@ -30,6 +30,7 @@ import io.netty.util.internal.AppendableCharSequence;
 
 import static io.netty.buffer.ByteBufUtil.indexOf;
 import static io.netty.buffer.ByteBufUtil.readBytes;
+import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 /**
  * Decodes {@link ByteBuf}s into {@link StompHeadersSubframe}s and
@@ -90,16 +91,8 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
 
     public StompSubframeDecoder(int maxLineLength, int maxChunkSize, boolean validateHeaders) {
         super(State.SKIP_CONTROL_CHARACTERS);
-        if (maxLineLength <= 0) {
-            throw new IllegalArgumentException(
-                    "maxLineLength must be a positive integer: " +
-                            maxLineLength);
-        }
-        if (maxChunkSize <= 0) {
-            throw new IllegalArgumentException(
-                    "maxChunkSize must be a positive integer: " +
-                            maxChunkSize);
-        }
+        checkPositive(maxLineLength, "maxLineLength");
+        checkPositive(maxChunkSize, "maxChunkSize");
         this.maxChunkSize = maxChunkSize;
         this.maxLineLength = maxLineLength;
         this.validateHeaders = validateHeaders;

--- a/codec-xml/pom.xml
+++ b/codec-xml/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-codec-xml</artifactId>

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-codec</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-common</artifactId>

--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>io.netty</groupId>
   <artifactId>netty-dev-tools</artifactId>
-  <version>4.1.25.6.dse</version>
+  <version>4.1.25.7.dse</version>
 
   <name>Netty/Dev-Tools</name>
 
@@ -52,6 +52,5 @@
   </build>
 
   <scm>
-    <tag>netty-4.1.25.dse</tag>
   </scm>
 </project>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-example</artifactId>

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-handler-proxy</artifactId>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-handler</artifactId>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-microbench</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <groupId>io.netty</groupId>
   <artifactId>netty-parent</artifactId>
   <packaging>pom</packaging>
-  <version>4.1.25.6.dse</version>
+  <version>4.1.25.7.dse</version>
 
   <name>Netty</name>
   <url>http://netty.io/</url>
@@ -53,7 +53,6 @@
     <url>https://github.com/netty/netty</url>
     <connection>scm:git:git://github.com/netty/netty.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/netty/netty.git</developerConnection>
-    <tag>netty-4.1.25.dse</tag>
   </scm>
 
   <developers>

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-resolver-dns</artifactId>

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-resolver</artifactId>

--- a/tarball/pom.xml
+++ b/tarball/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-tarball</artifactId>

--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-autobahn</artifactId>

--- a/testsuite-http2/pom.xml
+++ b/testsuite-http2/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-http2</artifactId>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-osgi</artifactId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-testsuite</artifactId>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
   <artifactId>netty-transport-native-epoll</artifactId>
 

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
   <artifactId>netty-transport-native-kqueue</artifactId>
 

--- a/transport-native-unix-common-tests/pom.xml
+++ b/transport-native-unix-common-tests/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
   <artifactId>netty-transport-native-unix-common-tests</artifactId>
 

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
   <artifactId>netty-transport-native-unix-common</artifactId>
 

--- a/transport-rxtx/pom.xml
+++ b/transport-rxtx/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-transport-rxtx</artifactId>

--- a/transport-sctp/pom.xml
+++ b/transport-sctp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-transport-sctp</artifactId>

--- a/transport-udt/pom.xml
+++ b/transport-udt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-transport-udt</artifactId>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.25.6.dse</version>
+    <version>4.1.25.7.dse</version>
   </parent>
 
   <artifactId>netty-transport</artifactId>


### PR DESCRIPTION
https://datastax.jira.com/browse/DB-4068

This is a relatively straightforward `git cherry-pick -x [...]`.  The cherry series was selected as discussed in the JIRA issue and applied clean.  The last commit is just capturing `mvn versions:set`.  That commit's message also records the upstream cherry hashes with their PR/issue/CVE links.