### PR TITLE
Delete OSX KQueue support from build.yaml (bdp 5.1/Netty 4.0.54)

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2,21 +2,15 @@ schedules:
   adhoc:
     schedule: adhoc
 os:
-  - osx/high-sierra
   - ubuntu/trusty64
 java:
   - oraclejdk8
 build:
   - script: |
       echo "OS VERSION ===== $OS_VERSION"
-      if [ "$OS_VERSION" = "osx/high-sierra" ]; then
-         mvn -B clean -DskipTests
-         mvn -B -pl transport-native-unix-common,transport-native-kqueue -Partifactory deploy -DskipTests -DaltDeploymentRepository="artifactory::default::https://repo.sjc.dsinternal.org/artifactory/datastax-releases-local"
-      else
-         export DEBIAN_FRONTEND=noninteractive
-         export MAVEN_HOME=/home/jenkins/.mvn/apache-maven-3.2.5
-         export PATH=$MAVEN_HOME/bin:$PATH
-         sudo apt-get update
-         sudo apt-get install -y autoconf automake libtool make tar gcc-multilib libaio-dev
-         mvn -B clean deploy -Partifactory -DskipTests -DaltDeploymentRepository="artifactory::default::https://repo.sjc.dsinternal.org/artifactory/datastax-releases-local"
-      fi
+      export DEBIAN_FRONTEND=noninteractive
+      export MAVEN_HOME=/home/jenkins/.mvn/apache-maven-3.2.5
+      export PATH=$MAVEN_HOME/bin:$PATH
+      sudo apt-get update
+      sudo apt-get install -y autoconf automake libtool make tar gcc-multilib libaio-dev
+      mvn -B clean deploy -Partifactory -DskipTests -DaltDeploymentRepository="artifactory::default::https://repo.sjc.dsinternal.org/artifactory/datastax-releases-local"


### PR DESCRIPTION
Netty 4.0.x never had native KQueue transport in its source tree, so it makes no sense to run an osx/high-sierra 4.0.x build out of build.yaml.  Deleting the OSX-specific logic branch and platform dependency declaration from build.yaml, while retaining the generic/ubuntu build logic and platform dependency.  This commit shouldn't move forward to the Netty 4.1.x line.

An artifact built from this PR branch's HEAD has already become bdp 5.1-dev's Netty dependency.  I'm just opening this github PR as a visible record of the change (as opposed to quietly merging locally and pushing).