### PR TITLE
DSP-23920: Support ARM64 platforms

### DIFF
--- a/BUILD-DATASTAX.md
+++ b/BUILD-DATASTAX.md
@@ -1,4 +1,4 @@
-Running the tests requires the following packages:
+## Running the tests requires the following packages:
 
 ```
 sudo apt-get install autoconf automake libtool make tar gcc \
@@ -14,7 +14,7 @@ sudo apt-get install autoconf automake libtool make tar gcc \
   a dependency of netty. It's not needed for building the project, but it is
   required for running the tests.
 
-The release script `./docker-datastax-release.sh` requires docker be installed:
+## The release script `./docker-datastax-release.sh` requires docker be installed:
 
 * `sudo apt-get install docker.io` to install docker.
 * `sudo usermod -aG docker $USER` to allow the current user to run docker.
@@ -22,5 +22,23 @@ The release script `./docker-datastax-release.sh` requires docker be installed:
 * Setup the username and password for the artifactory server in
   `~/.m2/settings.xml`.
 * Then run `./docker-datastax-release.sh`.
-* Follow this by releasing the MacOS specific kqueue library (must be run on MacOS):
-  `./mvnw clean && JAVA_HOME=$(/usr/libexec/java_home -v 1.8) ./mvnw -B -U -pl transport-native-unix-common,transport-native-kqueue -Partifactory deploy -DskipTests -DaltDeploymentRepository="artifactory::default::https://repo.aws.dsinternal.org/artifactory/datastax-releases-local"`
+
+## The next steps should each be run from a machine with the specific platform/architecture combinations below:
+
+### Linux ARM64/aarch_64 Epoll libraries
+* The following needs to be run from a Linux ARM64 platform (i.e. Graviton EC2 instance)
+```
+./mvnw clean && JAVA_HOME=$(/usr/libexec/java_home -v 1.8) ./mvnw -B -U -pl transport-native-unix-common,transport-native-epoll -Partifactory deploy -DskipTests -DaltDeploymentRepository="artifactory::default::https://repo.aws.dsinternal.org/artifactory/datastax-releases-local"
+```
+
+### MacOS AMD64/x86_64 KQueue libraries
+* The follwoing needs to be run from an Intel based Mac:
+```
+./mvnw clean && JAVA_HOME=$(/usr/libexec/java_home -v 1.8) ./mvnw -B -U -pl resolver-dns-native-macos,transport-native-unix-common,transport-native-kqueue -Partifactory deploy -DskipTests -DaltDeploymentRepository="artifactory::default::https://repo.aws.dsinternal.org/artifactory/datastax-releases-local"
+```
+### MacOS ARM64/aarch_64 KQueue libraries
+* The following needs to be run from an Apple Silicon based Mac (i.e. M1, M2, M3, etc)
+```
+./mvnw clean && JAVA_HOME=$(/usr/libexec/java_home -v 1.8) ./mvnw -B -U -Pmac-m1-cross-compile -pl resolver-dns-native-macos,transport-native-unix-common,transport-native-kqueue -Partifactory deploy -DskipTests -DaltDeploymentRepository="artifactory::default::https://repo.aws.dsinternal.org/artifactory/datastax-releases-local"
+```
+

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-all</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>io.netty</groupId>
   <artifactId>netty-bom</artifactId>
-  <version>4.1.100.1.dse</version>
+  <version>4.1.100.2.dse</version>
   <packaging>pom</packaging>
 
   <name>Netty/BOM</name>

--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-buffer</artifactId>

--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-dns</artifactId>

--- a/codec-haproxy/pom.xml
+++ b/codec-haproxy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-haproxy</artifactId>

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-http</artifactId>

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-http2</artifactId>

--- a/codec-memcache/pom.xml
+++ b/codec-memcache/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-memcache</artifactId>

--- a/codec-mqtt/pom.xml
+++ b/codec-mqtt/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-mqtt</artifactId>

--- a/codec-redis/pom.xml
+++ b/codec-redis/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-redis</artifactId>

--- a/codec-smtp/pom.xml
+++ b/codec-smtp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-smtp</artifactId>

--- a/codec-socks/pom.xml
+++ b/codec-socks/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-socks</artifactId>

--- a/codec-stomp/pom.xml
+++ b/codec-stomp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-stomp</artifactId>

--- a/codec-xml/pom.xml
+++ b/codec-xml/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-xml</artifactId>

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-codec</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-common</artifactId>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-example</artifactId>

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-handler-proxy</artifactId>

--- a/handler-ssl-ocsp/pom.xml
+++ b/handler-ssl-ocsp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-handler-ssl-ocsp</artifactId>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-handler</artifactId>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-microbench</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <groupId>io.netty</groupId>
   <artifactId>netty-parent</artifactId>
   <packaging>pom</packaging>
-  <version>4.1.100.1.dse</version>
+  <version>4.1.100.2.dse</version>
 
   <name>Netty</name>
   <url>https://netty.io/</url>

--- a/resolver-dns-classes-macos/pom.xml
+++ b/resolver-dns-classes-macos/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
   <artifactId>netty-resolver-dns-classes-macos</artifactId>
 

--- a/resolver-dns-native-macos/pom.xml
+++ b/resolver-dns-native-macos/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
   <artifactId>netty-resolver-dns-native-macos</artifactId>
 

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-resolver-dns</artifactId>

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-resolver</artifactId>

--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-autobahn</artifactId>

--- a/testsuite-http2/pom.xml
+++ b/testsuite-http2/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-http2</artifactId>

--- a/testsuite-native-image-client-runtime-init/pom.xml
+++ b/testsuite-native-image-client-runtime-init/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-native-image-client-runtime-init</artifactId>

--- a/testsuite-native-image-client/pom.xml
+++ b/testsuite-native-image-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-native-image-client</artifactId>

--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-native-image</artifactId>

--- a/testsuite-native/pom.xml
+++ b/testsuite-native/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-native</artifactId>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-osgi</artifactId>

--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-shading</artifactId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite</artifactId>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-transport-blockhound-tests</artifactId>

--- a/transport-classes-epoll/pom.xml
+++ b/transport-classes-epoll/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
   <artifactId>netty-transport-classes-epoll</artifactId>
 

--- a/transport-classes-kqueue/pom.xml
+++ b/transport-classes-kqueue/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
   <artifactId>netty-transport-classes-kqueue</artifactId>
 

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
   <artifactId>netty-transport-native-epoll</artifactId>
 

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -316,7 +316,7 @@
                     <arg>${jni.compiler.args.cflags}</arg>
                     <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
                     <configureArg>--host=aarch64-linux-gnu</configureArg>
-                    <configureArg>CC=aarch64-none-linux-gnu-gcc</configureArg>
+                    <configureArg>CC=gcc</configureArg>
                   </configureArgs>
                 </configuration>
                 <goals>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -74,39 +74,6 @@
             </plugin>
           </plugins>
         </pluginManagement>
-        <plugins>
-          <plugin>
-            <artifactId>maven-enforcer-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>enforce-release-environment</id>
-                <goals>
-                  <goal>enforce</goal>
-                </goals>
-                <configuration>
-                  <rules>
-                    <requireProperty>
-                      <regexMessage>
-                        Release process must be performed on linux-x86_64.
-                      </regexMessage>
-                      <property>os.detected.classifier</property>
-                      <regex>^linux-x86_64$</regex>
-                    </requireProperty>
-                    <requireFilesContent>
-                      <message>
-                        Release process must be performed on RHEL 6.8 or its derivatives.
-                      </message>
-                      <files>
-                        <file>/etc/redhat-release</file>
-                      </files>
-                      <content>release 6.9</content>
-                    </requireFilesContent>
-                  </rules>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
       </build>
     </profile>
     <profile>
@@ -242,37 +209,6 @@
           </plugins>
         </pluginManagement>
         <plugins>
-          <plugin>
-            <artifactId>maven-enforcer-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>enforce-release-environment</id>
-                <goals>
-                  <goal>enforce</goal>
-                </goals>
-                <configuration>
-                  <rules>
-                    <requireProperty>
-                      <regexMessage>
-                        Cross compile and Release process must be performed on linux-x86_64.
-                      </regexMessage>
-                      <property>os.detected.classifier</property>
-                      <regex>^linux-x86_64.*</regex>
-                    </requireProperty>
-                    <requireFilesContent>
-                      <message>
-                        Cross compile and Release process must be performed on RHEL 7.6 or its derivatives.
-                      </message>
-                      <files>
-                        <file>/etc/redhat-release</file>
-                      </files>
-                      <content>release 7.6</content>
-                    </requireFilesContent>
-                  </rules>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
           <plugin>
             <artifactId>maven-dependency-plugin</artifactId>
             <executions>

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
   <artifactId>netty-transport-native-kqueue</artifactId>
 

--- a/transport-native-unix-common-tests/pom.xml
+++ b/transport-native-unix-common-tests/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
   <artifactId>netty-transport-native-unix-common-tests</artifactId>
 

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -388,8 +388,8 @@
         <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
         <jni.classifier>${os.detected.name}-aarch_64</jni.classifier>
         <jni.platform>linux</jni.platform>
-        <exe.compiler>aarch64-none-linux-gnu-gcc</exe.compiler>
-        <exe.archiver>aarch64-none-linux-gnu-ar</exe.archiver>
+        <exe.compiler>gcc</exe.compiler>
+        <exe.archiver>ar</exe.archiver>
       </properties>
       <build>
         <plugins>

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
   <artifactId>netty-transport-native-unix-common</artifactId>
 

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/FileDescriptor.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/FileDescriptor.java
@@ -26,6 +26,7 @@ import static io.netty.channel.unix.Errors.newIOException;
 import static io.netty.channel.unix.Limits.IOV_MAX;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+import static io.netty.util.internal.PlatformDependent;
 import static java.lang.Math.min;
 
 /**
@@ -37,12 +38,22 @@ public class FileDescriptor {
     private static final AtomicIntegerFieldUpdater<FileDescriptor> stateUpdater =
             AtomicIntegerFieldUpdater.newUpdater(FileDescriptor.class, "state");
 
+    {
+        String arch = PlatformDependent.normalizedArch();
+        if ("x86_64".equals(arch)) {
+            O_DIRECT = 040000;
+        } else if("aarch64".equals(arch)) {
+            // https://elixir.bootlin.com/linux/latest/source/arch/arm64/include/uapi/asm/fcntl.h#L25
+            O_DIRECT = 0200000;
+        }
+    }
+
     public static final int O_RDONLY = 00;
     public static final int O_WRONLY = 01;
     public static final int O_CREAT = 0100;
     public static final int O_TRUNC = 01000;
     public static final int O_APPEND = 02000;
-    public static final int O_DIRECT = 040000;
+    public static int O_DIRECT;
 
     private static final int STATE_CLOSED_MASK = 1;
     private static final int STATE_INPUT_SHUTDOWN_MASK = 1 << 1;

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/FileDescriptor.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/FileDescriptor.java
@@ -42,7 +42,7 @@ public class FileDescriptor {
         String arch = PlatformDependent.normalizedArch();
         if ("x86_64".equals(arch)) {
             O_DIRECT = 040000;
-        } else if("aarch64".equals(arch)) {
+        } else if ("aarch64".equals(arch)) {
             // https://elixir.bootlin.com/linux/latest/source/arch/arm64/include/uapi/asm/fcntl.h#L25
             O_DIRECT = 0200000;
         }

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/FileDescriptor.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/FileDescriptor.java
@@ -26,7 +26,7 @@ import static io.netty.channel.unix.Errors.newIOException;
 import static io.netty.channel.unix.Limits.IOV_MAX;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
-import static io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.PlatformDependent;
 import static java.lang.Math.min;
 
 /**

--- a/transport-rxtx/pom.xml
+++ b/transport-rxtx/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-transport-rxtx</artifactId>

--- a/transport-sctp/pom.xml
+++ b/transport-sctp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-transport-sctp</artifactId>

--- a/transport-udt/pom.xml
+++ b/transport-udt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-transport-udt</artifactId>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.100.1.dse</version>
+    <version>4.1.100.2.dse</version>
   </parent>
 
   <artifactId>netty-transport</artifactId>


### PR DESCRIPTION
This allows for ARM64 platforms to use `O_DIRECT` correctly and documents the steps for building and publishing the 4 combinations of native libraries for Netty (linux/amd64, linux/arm64, macos/amd64 macos/arm64)