### PR TITLE
[DO NOT MERGE] Dse netty 4.1.128.2

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-all</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>io.netty</groupId>
   <artifactId>netty-bom</artifactId>
-  <version>4.1.128.1.dse</version>
+  <version>4.1.128.2.dse</version>
   <packaging>pom</packaging>
 
   <name>Netty/BOM</name>

--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-buffer</artifactId>

--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-dns</artifactId>

--- a/codec-haproxy/pom.xml
+++ b/codec-haproxy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-haproxy</artifactId>

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-http</artifactId>

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-http2</artifactId>

--- a/codec-memcache/pom.xml
+++ b/codec-memcache/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-memcache</artifactId>

--- a/codec-mqtt/pom.xml
+++ b/codec-mqtt/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-mqtt</artifactId>

--- a/codec-redis/pom.xml
+++ b/codec-redis/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-redis</artifactId>

--- a/codec-smtp/pom.xml
+++ b/codec-smtp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-smtp</artifactId>

--- a/codec-socks/pom.xml
+++ b/codec-socks/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-socks</artifactId>

--- a/codec-stomp/pom.xml
+++ b/codec-stomp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-stomp</artifactId>

--- a/codec-xml/pom.xml
+++ b/codec-xml/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-codec-xml</artifactId>

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-codec</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-common</artifactId>

--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-dev-tools</artifactId>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-example</artifactId>

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-handler-proxy</artifactId>

--- a/handler-ssl-ocsp/pom.xml
+++ b/handler-ssl-ocsp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-handler-ssl-ocsp</artifactId>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-handler</artifactId>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-microbench</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <groupId>io.netty</groupId>
   <artifactId>netty-parent</artifactId>
   <packaging>pom</packaging>
-  <version>4.1.128.1.dse</version>
+  <version>4.1.128.2.dse</version>
 
   <name>Netty</name>
   <url>https://netty.io/</url>

--- a/resolver-dns-classes-macos/pom.xml
+++ b/resolver-dns-classes-macos/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
   <artifactId>netty-resolver-dns-classes-macos</artifactId>
 

--- a/resolver-dns-native-macos/pom.xml
+++ b/resolver-dns-native-macos/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
   <artifactId>netty-resolver-dns-native-macos</artifactId>
 

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-resolver-dns</artifactId>

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-resolver</artifactId>

--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-autobahn</artifactId>

--- a/testsuite-http2/pom.xml
+++ b/testsuite-http2/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-http2</artifactId>

--- a/testsuite-native-image-client-runtime-init/pom.xml
+++ b/testsuite-native-image-client-runtime-init/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-native-image-client-runtime-init</artifactId>

--- a/testsuite-native-image-client/pom.xml
+++ b/testsuite-native-image-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-native-image-client</artifactId>

--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-native-image</artifactId>

--- a/testsuite-native/pom.xml
+++ b/testsuite-native/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-native</artifactId>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-osgi</artifactId>

--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite-shading</artifactId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-testsuite</artifactId>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-transport-blockhound-tests</artifactId>

--- a/transport-classes-epoll/pom.xml
+++ b/transport-classes-epoll/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
   <artifactId>netty-transport-classes-epoll</artifactId>
 

--- a/transport-classes-kqueue/pom.xml
+++ b/transport-classes-kqueue/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
   <artifactId>netty-transport-classes-kqueue</artifactId>
 

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
   <artifactId>netty-transport-native-epoll</artifactId>
 

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -38,7 +38,7 @@
     <unix.common.lib.unpacked.dir>${unix.common.lib.dir}/META-INF/native/lib</unix.common.lib.unpacked.dir>
     <unix.common.include.unpacked.dir>${unix.common.lib.dir}/META-INF/native/include</unix.common.include.unpacked.dir>
     <jni.compiler.args.cflags>CFLAGS=-O2 -pipe -Werror -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden -D_FORTIFY_SOURCE=2 -ffunction-sections -fdata-sections -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
-    <jni.compiler.args.ldflags>LDFLAGS=-Wl,-z,relro -Wl,-z,now -Wl,--as-needed -Wl,--gc-sections -L${unix.common.lib.unpacked.dir} -laio</jni.compiler.args.ldflags>
+    <jni.compiler.args.ldflags>LDFLAGS=-Wl,-z,relro -Wl,-z,now -Wl,--as-needed -Wl,--gc-sections -L${unix.common.lib.unpacked.dir}</jni.compiler.args.ldflags>
     <jni.compiler.args.libs>LIBS=-Wl,--whole-archive -l${unix.common.lib.name} -Wl,--no-whole-archive -ldl -lrt</jni.compiler.args.libs>
     <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
     <skipTests>true</skipTests>

--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <dlfcn.h>
 #include <libaio.h>
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
@@ -794,6 +795,53 @@ static jint netty_epoll_native_registerUnix(JNIEnv* env, jclass clazz) {
 
 //LibAIO methods
 
+// Dynamic loading of libaio functions
+static void* libaio_handle = NULL;
+static int (*libaio_io_setup)(int maxevents, io_context_t *ctxp) = NULL;
+static int (*libaio_io_submit)(io_context_t ctx, long nr, struct iocb *ios[]) = NULL;
+static int (*libaio_io_getevents)(io_context_t ctx_id, long min_nr, long nr, struct io_event *events, struct timespec *timeout) = NULL;
+static int (*libaio_io_destroy)(io_context_t ctx) = NULL;
+
+static int load_libaio() {
+    int i;
+    if (libaio_handle != NULL) {
+        return 0; // Already loaded
+    }
+
+    // Try different library names for compatibility
+    const char* lib_names[] = {
+        "libaio.so.1t64",  // Newer Ubuntu/Debian with time64
+        "libaio.so.1",     // Older systems
+        "libaio.so",       // Fallback
+        NULL
+    };
+
+    for (i = 0; lib_names[i] != NULL; i++) {
+        libaio_handle = dlopen(lib_names[i], RTLD_LAZY | RTLD_LOCAL);
+        if (libaio_handle != NULL) {
+            break;
+        }
+    }
+
+    if (libaio_handle == NULL) {
+        return -1;
+    }
+
+    // Load function pointers
+    libaio_io_setup = dlsym(libaio_handle, "io_setup");
+    libaio_io_submit = dlsym(libaio_handle, "io_submit");
+    libaio_io_getevents = dlsym(libaio_handle, "io_getevents");
+    libaio_io_destroy = dlsym(libaio_handle, "io_destroy");
+
+    if (!libaio_io_setup || !libaio_io_submit || !libaio_io_getevents || !libaio_io_destroy) {
+        dlclose(libaio_handle);
+        libaio_handle = NULL;
+        return -1;
+    }
+
+    return 0;
+}
+
 // the maximum number of buffers for a vectored IO request
 #define MAX_NUM_BUFFERS_PER_REQUEST 8
 
@@ -819,6 +867,12 @@ static jlong netty_epoll_native_createAIOContext0(JNIEnv* env, jclass clazz, jin
         return JNI_ERR;
     }
 
+    // Load libaio dynamically if not already loaded
+    if (load_libaio() != 0) {
+        netty_unix_errors_throwRuntimeException(env, "Failed to load libaio library. Tried: libaio.so.1t64, libaio.so.1, libaio.so");
+        return JNI_ERR;
+    }
+
     netty_io_context_t* ctx = malloc(sizeof(netty_io_context_t));
     ctx->aio = 0;
     ctx->concurrency = concurrency;
@@ -830,7 +884,7 @@ static jlong netty_epoll_native_createAIOContext0(JNIEnv* env, jclass clazz, jin
     }
 
     int r;
-    r = io_setup(concurrency, &(ctx->aio));
+    r = libaio_io_setup(concurrency, &(ctx->aio));
     if (r != 0) {
         netty_unix_errors_throwChannelExceptionErrorNo(env, "io_setup() failed: ", -r);
     }
@@ -942,7 +996,7 @@ static void netty_epoll_native_submitAIORead0(JNIEnv* env, jclass clazz, jlong c
     }
 
     //printf("Submitting request\n");
-    int r = io_submit(ctx->aio, num_requests, iocbps);
+    int r = libaio_io_submit(ctx->aio, num_requests, iocbps);
     if (r != num_requests) {
         //printf("io_submit() failed with %d\n", r);
         netty_unix_errors_throwChannelExceptionErrorNo(env, "io_submit() failed: ", -r);
@@ -980,7 +1034,7 @@ static jint netty_epoll_native_getAIOEvents0(JNIEnv* env, jclass clazz, jlong ct
     timeout.tv_nsec = 0;
 
     int r, j, slot;
-    r = io_getevents(ctx->aio, 1, ctx->concurrency, events, &timeout);
+    r = libaio_io_getevents(ctx->aio, 1, ctx->concurrency, events, &timeout);
     //printf("io_getevents() returned %d\n", r);
 
     if (r > 0) {

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
   <artifactId>netty-transport-native-kqueue</artifactId>
 

--- a/transport-native-unix-common-tests/pom.xml
+++ b/transport-native-unix-common-tests/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
   <artifactId>netty-transport-native-unix-common-tests</artifactId>
 

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
   <artifactId>netty-transport-native-unix-common</artifactId>
 

--- a/transport-rxtx/pom.xml
+++ b/transport-rxtx/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-transport-rxtx</artifactId>

--- a/transport-sctp/pom.xml
+++ b/transport-sctp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-transport-sctp</artifactId>

--- a/transport-udt/pom.xml
+++ b/transport-udt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-transport-udt</artifactId>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
-    <version>4.1.128.1.dse</version>
+    <version>4.1.128.2.dse</version>
   </parent>
 
   <artifactId>netty-transport</artifactId>


### PR DESCRIPTION
This is just a Draft PR to show the changes required to load the `libaio` libraries dynamically, instead of compiling against them statically. This aims to resolve an issue where compiling on older Ubuntu (20.04) causes the native libraries built to look for `libaio.so.1`, but running on newer Ubuntu (24.04) fails to find the library because it is named `libaio.so.1t64`.